### PR TITLE
ci(workflow): add spotless ktlint checks

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,19 @@
+root = true
+
+[*]
+charset = utf-8
+indent_style = space
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.{kt,kts}]
+indent_size = 4
+ktlint_standard = enabled
+ktlint_experimental = enabled
+ktlint_code_style = android_studio
+ktlint_standard_comment-spacing = disabled
+ktlint_standard_package-name = disabled
+ktlint_experimental_package-naming = enabled
+ij_kotlin_allow_trailing_comma = true
+ij_kotlin_allow_trailing_comma_on_call_site = true
+ktlint_standard_backing-property-naming = disabled

--- a/.github/workflows/build-on-pull.yml
+++ b/.github/workflows/build-on-pull.yml
@@ -27,9 +27,6 @@ jobs:
     - name: Build with Gradle
       run: ./gradlew assembleDebug
 
-    - name: Run Android Lint
-      run: ./gradlew lint
-
     - name: Run Tests
       run: ./gradlew test
 

--- a/.github/workflows/lint-on-pull.yml
+++ b/.github/workflows/lint-on-pull.yml
@@ -1,0 +1,31 @@
+name: Lint on Pull Request
+
+on:
+  workflow_dispatch:
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v6
+
+    - name: Validate Gradle Wrapper
+      uses: gradle/actions/wrapper-validation@v3
+
+    - name: Set up JDK 17
+      uses: actions/setup-java@v5
+      with:
+        distribution: 'temurin'
+        java-version: '17'
+        cache: gradle
+
+    - name: Check Kotlin code style
+      run: ./gradlew spotlessCheck --continue
+
+    - name: Run Android Lint
+      run: ./gradlew lint

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -63,6 +63,20 @@ To update the wiki, simply navigate to the [wiki tab](https://github.com/octoshr
 **If build fails, please edit the pull request in order to make the build succeed.**
 
 
+## Git Hooks (Optional but Recommended)
+We enforce code style (KtLint via Spotless) and code quality (Android Lint) on all Pull Requests. To catch these errors locally before you push, you can install our pre-commit hook:
+
+```bash
+./gradlew installGitHooks
+```
+
+Once installed, the hook will:
+1. **Auto-fix formatting:** It will run `spotlessApply` and automatically stage the fixes for you (unless you are doing a partial commit with `git add -p`, in which case it will safely abort to protect your unstaged changes).
+2. **Check for bugs:** It will run Android Lint and block the commit if any errors are found, pointing you to the report.
+
+*(If you ever need to bypass the hook in an emergency, use `git commit --no-verify`).*
+
+
 ## Helpful Tips
 ### Getting Your Pull Request Merged
 When submitting a pull request, please be as detailed as possible in your reasoning for the change, what you changed and how you tested it. \

--- a/build.gradle
+++ b/build.gradle
@@ -32,6 +32,7 @@ buildscript {
     ext.rxjava_version = '2.1.4'
     ext.rxkotlin_version = '2.1.0'
     ext.rx_preferences_version = '2.0.0-RC3'
+    ext.spotless_version = '8.1.0'
     ext.timber_version = '5.0.1'
     ext.androidx_work_version = "2.8.0"
 
@@ -54,6 +55,7 @@ buildscript {
         classpath 'com.google.gms:google-services:4.3.14'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath "io.realm:realm-gradle-plugin:$realm_version"
+        classpath "com.diffplug.spotless:spotless-plugin-gradle:$spotless_version"
     }
 }
 
@@ -76,6 +78,15 @@ tasks.register('clean', Delete) {
 }
 
 subprojects {
+    apply plugin: 'com.diffplug.spotless'
+
+    spotless {
+        kotlin {
+            target '**/*.kt', '**/*.kts'
+            ktlint()
+        }
+    }
+
     afterEvaluate {
         if (project.hasProperty('kapt')) {
             kapt {
@@ -87,4 +98,12 @@ subprojects {
             }
         }
     }
+}
+
+tasks.register('installGitHooks', Copy) {
+    description = "Installs the pre-commit git hooks"
+    group = "help"
+    from new File(rootProject.rootDir, 'scripts/git-hooks/pre-commit')
+    into { new File(rootProject.rootDir, '.git/hooks') }
+    fileMode 0774
 }

--- a/scripts/git-hooks/pre-commit
+++ b/scripts/git-hooks/pre-commit
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+echo "⏳ Running Pre-commit Checks..."
+
+OVERLAPPING_FILES=$(comm -12 <(git diff --name-only | sort) <(git diff --name-only --cached | sort))
+
+echo "🔍 Checking code style with Spotless..."
+
+set +e
+./gradlew spotlessCheck --quiet
+SPOTLESS_EXIT_CODE=$?
+set -e
+
+if [ $SPOTLESS_EXIT_CODE -ne 0 ]; then
+    if [ -n "$OVERLAPPING_FILES" ]; then
+        echo ""
+        echo "⚠️ Formatting errors detected, but you have partially staged files:"
+        echo "$OVERLAPPING_FILES"
+        echo ""
+        echo "Auto-fixing was skipped to protect your unstaged changes from being committed."
+        echo "Run './gradlew spotlessApply' to fix the file(s) and re-stage your changes."
+        exit 1
+    else
+        echo "🔧 Auto-fixing formatting issues..."
+        ./gradlew spotlessApply --continue --quiet
+
+        STAGED_FILES=$(git diff --name-only --cached)
+        for file in $STAGED_FILES; do
+            if [ -f "$file" ]; then
+                git add "$file"
+            fi
+        done
+        echo "✅ Formatting auto-fixed and staged!"
+    fi
+else
+    echo "✅ Code style is Spotless!"
+fi
+
+echo "🔍 Checking code quality with Android Lint..."
+
+set +e
+./gradlew lint
+LINT_EXIT_CODE=$?
+set -e
+
+if [ $LINT_EXIT_CODE -ne 0 ]; then
+    echo ""
+    echo "❌ Commit rejected due to Android Lint errors."
+    echo "Please review the reports in the build/reports/ directory of each module."
+    echo "After fixing, re-stage your changes."
+    exit 1
+fi
+
+echo "✅ Android Lint passed!"
+
+exit 0


### PR DESCRIPTION
# `.editorconfig`
- 4-space indentation
- IntelliJ IDEA code style
- Enabled standard and experimental ktlint rules
- Disabled rules for Android compatibility (comment spacing, package naming, backing property naming)

# `build.gradle` files
- Sorted Gradle extra properties
- Added Spotless Plugin
- Applied Plugin to Modules excluding `android-smsmms`
- Configured Ktlint

# `build-on-pull.yml` workflow
- spotlessCheck (fastest) catches formatting issues 
- Android-specific linting (slower but still quick), validates code quality before build
- Build only proceeds if quality checks pass
- Stops pipeline early on any quality violations
- Quality checks together, then build, then validation
- Keeps expensive operations (build, tests) after lightweight checks                                   
- Android lint may be slower than spotless; if this causes issues, we could lint after build

# Consider for `build-and-release.yml`
?????????