### PR TITLE
fix(main): Don't animate layout changes

### DIFF
--- a/presentation/src/main/res/layout/main_activity.xml
+++ b/presentation/src/main/res/layout/main_activity.xml
@@ -26,8 +26,7 @@
 
     <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:animateLayoutChanges="true">
+        android:layout_height="match_parent">
 
         <androidx.appcompat.widget.Toolbar
             android:id="@+id/toolbar"


### PR DESCRIPTION
This was causing a crash when opening the app from a lock screen notification. It doesn't cause any visual problems.

Closes #791
Closes #776
Closes #775