### PR TITLE
feat: Send emoji reactions (react to messages, not just parse incoming)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ buildscript {
     ext.junit_version = '4.12'
     ext.kotlin_version = '1.7.21'
     ext.lifecycle_version = '2.1.0'
-    ext.material_version = '1.0.0'
+    ext.material_version = '1.6.1'
     ext.mockito_version = '2.18.3'
     ext.moshi_version = '1.8.0'
     ext.okhttp3_version = '4.10.0'

--- a/data/src/main/assets/emojis/en.json
+++ b/data/src/main/assets/emojis/en.json
@@ -18,5 +18,26 @@
   "emoji_reaction_ios_exclamation_removed": "^(?s)Removed an exclamation from “(.+?)”$",
 
   "emoji_reaction_ios_question_mark_added": "^(?s)Questioned “(.+?)”$",
-  "emoji_reaction_ios_question_mark_removed": "^(?s)Removed a question mark from “(.+?)”$"
+  "emoji_reaction_ios_question_mark_removed": "^(?s)Removed a question mark from “(.+?)”$",
+
+  "emoji_reaction_ios_generic_added_template": "Reacted %1$s to “%2$s”",
+  "emoji_reaction_ios_generic_removed_template": "Removed %1$s from “%2$s”",
+
+  "emoji_reaction_ios_heart_added_template": "Loved “%s”",
+  "emoji_reaction_ios_heart_removed_template": "Removed a heart from “%s”",
+
+  "emoji_reaction_ios_like_added_template": "Liked “%s”",
+  "emoji_reaction_ios_like_removed_template": "Removed a like from “%s”",
+
+  "emoji_reaction_ios_dislike_added_template": "Disliked “%s”",
+  "emoji_reaction_ios_dislike_removed_template": "Removed a dislike from “%s”",
+
+  "emoji_reaction_ios_laugh_added_template": "Laughed at “%s”",
+  "emoji_reaction_ios_laugh_removed_template": "Removed a laugh from “%s”",
+
+  "emoji_reaction_ios_exclamation_added_template": "Emphasized “%s”",
+  "emoji_reaction_ios_exclamation_removed_template": "Removed an exclamation from “%s”",
+
+  "emoji_reaction_ios_question_mark_added_template": "Questioned “%s”",
+  "emoji_reaction_ios_question_mark_removed_template": "Removed a question mark from “%s”"
 }

--- a/data/src/main/java/com/moez/QKSMS/migration/QkRealmMigration.kt
+++ b/data/src/main/java/com/moez/QKSMS/migration/QkRealmMigration.kt
@@ -37,7 +37,7 @@ class QkRealmMigration @Inject constructor(
 ) : RealmMigration {
 
     companion object {
-        const val SCHEMA_VERSION: Long = 15
+        const val SCHEMA_VERSION: Long = 16
     }
 
     @SuppressLint("ApplySharedPref")
@@ -296,6 +296,20 @@ class QkRealmMigration @Inject constructor(
                 realm.schema.get("Message")
                     ?.addField("sendAsGroup", Boolean::class.java, FieldAttribute.REQUIRED)
             }
+
+            version ++
+        }
+
+        if (version == 15L) {
+            realm.schema.get("EmojiReaction")
+                ?.takeIf { it.hasField("fromMe").not() }
+                ?.addField("fromMe", Boolean::class.java, FieldAttribute.REQUIRED)
+                ?.transform { reaction -> reaction.setBoolean("fromMe", false) }
+
+            realm.schema.get("EmojiReaction")
+                ?.takeIf { it.hasField("format").not() }
+                ?.addField("format", String::class.java, FieldAttribute.REQUIRED)
+                ?.transform { reaction -> reaction.setString("format", "") }
 
             version ++
         }

--- a/data/src/main/java/com/moez/QKSMS/repository/EmojiReactionRepositoryImpl.kt
+++ b/data/src/main/java/com/moez/QKSMS/repository/EmojiReactionRepositoryImpl.kt
@@ -24,23 +24,35 @@ import dev.octoshrimpy.quik.manager.KeyManager
 import dev.octoshrimpy.quik.model.EmojiReaction
 import dev.octoshrimpy.quik.model.Message
 import dev.octoshrimpy.quik.util.EmojiPatternStrings
+import dev.octoshrimpy.quik.util.Preferences
 import io.realm.Realm
 import io.realm.Sort
 import timber.log.Timber
+import java.util.Locale
 import javax.inject.Inject
 
 class EmojiReactionRepositoryImpl @Inject constructor(
     private val context: Context,
     private val keyManager: KeyManager,
     private val moshi: Moshi,
+    private val prefs: Preferences,
 ) : EmojiReactionRepository {
+    companion object {
+        // Invisible delimiters used by the Google Messages reaction wire format
+        private const val HAIR = " "  // hair space, wraps the message parts
+        private const val ZWSP = "​"  // zero-width space, wraps the emoji when reacting
+        private const val ZWNJ = "‌"  // zero-width non-joiner, wraps the emoji when un-reacting
+    }
+
+    // Locale-tagged pattern/template strings loaded from assets, kept for outgoing generation
+    private val patternStringsByLocale = mutableMapOf<String, EmojiPatternStrings>()
     // We use an ordered map to make sure we can test tapback regexes before generic ones
     private val reactionPatterns: LinkedHashMap<Regex, (MatchResult) -> ParsedEmojiReaction?> = linkedMapOf(
         Regex( // Google Messages
             "(?s)^\u200a[^\u200b\u200a]*\u200b([^\u200b]*)\u200b[^\u200b\u200a]*\u200a(.*)\u200a[^\u200b\u200a]*\u200a\\Z"
         ) to { match ->
             ParsedEmojiReaction(
-            match.groupValues[1], match.groupValues[2]
+            match.groupValues[1], match.groupValues[2], format = EmojiReaction.FORMAT_GOOGLE
             )
         }
     )
@@ -49,7 +61,8 @@ class EmojiReactionRepositoryImpl @Inject constructor(
             "(?s)^\u200a[^\u200c\u200a]*\u200c([^\u200c]*)\u200c[^\u200c\u200a]*\u200a(.*)\u200a[^\u200c\u200a]*\u200a\\Z"
         ) to { match ->
             ParsedEmojiReaction(
-                match.groupValues[1], match.groupValues[2], isRemoval = true
+                match.groupValues[1], match.groupValues[2], isRemoval = true,
+                format = EmojiReaction.FORMAT_GOOGLE
             )
         }
     )
@@ -57,6 +70,7 @@ class EmojiReactionRepositoryImpl @Inject constructor(
     init {
         val assetEntries = loadEmojiPatternEntriesFromAssets()
         assetEntries.forEach { (localeTag, strings) ->
+            patternStringsByLocale[localeTag] = strings
             try {
                 addPatternsForLocaleStrings(localeTag, strings, reactionPatterns, removalPatterns)
             } catch (e: Exception) {
@@ -83,11 +97,11 @@ class EmojiReactionRepositoryImpl @Inject constructor(
         ).forEach { (emoji, added, removed) ->
             added?.let {
                 reactionPatterns[Regex(it)] =
-                    { match -> ParsedEmojiReaction(emoji, match.groupValues[1]) }
+                    { match -> ParsedEmojiReaction(emoji, match.groupValues[1], format = EmojiReaction.FORMAT_IOS_TAPBACK) }
             }
             removed?.let {
                 removalPatterns[Regex(it)] =
-                    { match -> ParsedEmojiReaction(emoji, match.groupValues[1], isRemoval = true) }
+                    { match -> ParsedEmojiReaction(emoji, match.groupValues[1], isRemoval = true, format = EmojiReaction.FORMAT_IOS_TAPBACK) }
             }
         }
 
@@ -95,12 +109,12 @@ class EmojiReactionRepositoryImpl @Inject constructor(
         strings.iosGenericAdded?.let { pattern ->
             reactionPatterns[Regex(pattern)] = { match ->
                 if (match.groupValues.getOrNull(1) == "with a sticker") null // TODO: localize "with a sticker"
-                else ParsedEmojiReaction(match.groupValues[1], match.groupValues[2])
+                else ParsedEmojiReaction(match.groupValues[1], match.groupValues[2], format = EmojiReaction.FORMAT_IOS_GENERIC)
             }
         }
         strings.iosGenericRemoved?.let { pattern ->
             removalPatterns[Regex(pattern)] = { match ->
-                ParsedEmojiReaction(match.groupValues[1], match.groupValues[2], isRemoval = true)
+                ParsedEmojiReaction(match.groupValues[1], match.groupValues[2], isRemoval = true, format = EmojiReaction.FORMAT_IOS_GENERIC)
             }
         }
 
@@ -159,6 +173,85 @@ class EmojiReactionRepositoryImpl @Inject constructor(
         return null
     }
 
+    override fun buildReactionBody(
+        emoji: String,
+        targetText: String,
+        isRemoval: Boolean,
+        format: String,
+    ): String = when {
+        format.startsWith("ios") -> buildIosReactionBody(emoji, targetText, isRemoval)
+        else -> buildGoogleReactionBody(emoji, targetText, isRemoval)
+    }
+
+    /**
+     * Reconstructs the invisible-delimiter encoding that Google Messages (and Quik's own parser)
+     * understand. The visible words are cosmetic; the hair-space / zero-width delimiters carry the
+     * structure, so this is locale-independent.
+     */
+    private fun buildGoogleReactionBody(emoji: String, targetText: String, isRemoval: Boolean): String {
+        val emojiDelim = if (isRemoval) ZWNJ else ZWSP
+        val verb = if (isRemoval) "Removed " else "Reacted "
+        val preposition = if (isRemoval) " from " else " to "
+        return HAIR + verb + emojiDelim + emoji + emojiDelim + preposition +
+                HAIR + targetText + HAIR + HAIR
+    }
+
+    private fun buildIosReactionBody(emoji: String, targetText: String, isRemoval: Boolean): String {
+        val strings = templatesForCurrentLocale()
+        iosTapbackTemplate(emoji, isRemoval, strings)?.let { template ->
+            return String.format(template, targetText)
+        }
+        val generic = when {
+            isRemoval -> strings?.iosGenericRemovedTemplate ?: "Removed %1\$s from “%2\$s”"
+            else -> strings?.iosGenericAddedTemplate ?: "Reacted %1\$s to “%2\$s”"
+        }
+        return String.format(generic, emoji, targetText)
+    }
+
+    /** Returns the iOS-readable template for one of the six standard tapback emojis, else null. */
+    private fun iosTapbackTemplate(
+        emoji: String,
+        isRemoval: Boolean,
+        strings: EmojiPatternStrings?,
+    ): String? = when (emoji) {
+        "❤️" -> if (isRemoval) strings?.iosHeartRemovedTemplate ?: "Removed a heart from “%s”"
+                else strings?.iosHeartAddedTemplate ?: "Loved “%s”"
+        "👍" -> if (isRemoval) strings?.iosLikeRemovedTemplate ?: "Removed a like from “%s”"
+                else strings?.iosLikeAddedTemplate ?: "Liked “%s”"
+        "👎" -> if (isRemoval) strings?.iosDislikeRemovedTemplate ?: "Removed a dislike from “%s”"
+                else strings?.iosDislikeAddedTemplate ?: "Disliked “%s”"
+        "😂" -> if (isRemoval) strings?.iosLaughRemovedTemplate ?: "Removed a laugh from “%s”"
+                else strings?.iosLaughAddedTemplate ?: "Laughed at “%s”"
+        "‼️" -> if (isRemoval) strings?.iosExclamationRemovedTemplate ?: "Removed an exclamation from “%s”"
+                else strings?.iosExclamationAddedTemplate ?: "Emphasized “%s”"
+        "❓" -> if (isRemoval) strings?.iosQuestionMarkRemovedTemplate ?: "Removed a question mark from “%s”"
+                else strings?.iosQuestionMarkAddedTemplate ?: "Questioned “%s”"
+        else -> null
+    }
+
+    private fun templatesForCurrentLocale(): EmojiPatternStrings? {
+        val locale = Locale.getDefault()
+        return patternStringsByLocale[locale.toLanguageTag().replace('-', '_')]
+            ?: patternStringsByLocale[locale.language]
+            ?: patternStringsByLocale["en"]
+    }
+
+    override fun resolveFormat(threadId: Long, realm: Realm): String =
+        when (prefs.reactionSendFormat.get()) {
+            Preferences.REACTION_FORMAT_GOOGLE -> EmojiReaction.FORMAT_GOOGLE
+            Preferences.REACTION_FORMAT_IOS -> EmojiReaction.FORMAT_IOS_TAPBACK
+            else -> {
+                // Auto: mirror the most recent reaction format we received in this thread
+                val lastReceived = realm.where(EmojiReaction::class.java)
+                    .equalTo("threadId", threadId)
+                    .equalTo("fromMe", false)
+                    .sort("id", Sort.DESCENDING)
+                    .findFirst()
+                if (lastReceived?.format?.startsWith("ios") == true) EmojiReaction.FORMAT_IOS_TAPBACK
+                else EmojiReaction.FORMAT_GOOGLE
+            }
+        }
+
     private fun parseTruncatedMessages(originalMessageText: String): Regex {
         val reactionText = originalMessageText.trim()
 
@@ -203,6 +296,13 @@ class EmojiReactionRepositoryImpl @Inject constructor(
         return null
     }
 
+    /**
+     * Two reactions are from the same reactor if they're both ours, or both incoming from the same
+     * address. Used to enforce one reaction per person per message.
+     */
+    private fun sameReactor(a: EmojiReaction, b: EmojiReaction): Boolean =
+        if (b.fromMe) a.fromMe else (!a.fromMe && a.senderAddress == b.senderAddress)
+
     private fun removeEmojiReaction(
         reactionMessage: Message,
         reaction: ParsedEmojiReaction,
@@ -214,8 +314,11 @@ class EmojiReactionRepositoryImpl @Inject constructor(
             return
         }
 
+        val fromMe = reactionMessage.isMe()
         val existingReaction = targetMessage.emojiReactions.find { candidate ->
-            candidate.senderAddress == reactionMessage.address && candidate.emoji == reaction.emoji
+            candidate.emoji == reaction.emoji &&
+                    if (fromMe) candidate.fromMe
+                    else (!candidate.fromMe && candidate.senderAddress == reactionMessage.address)
         }
 
         if (existingReaction != null) {
@@ -247,6 +350,8 @@ class EmojiReactionRepositoryImpl @Inject constructor(
             emoji = parsedReaction.emoji
             originalMessageText = parsedReaction.originalMessage
             threadId = reactionMessage.threadId
+            fromMe = reactionMessage.isMe()
+            format = parsedReaction.format
         }
         realm.insertOrUpdate(reaction)
 
@@ -254,8 +359,8 @@ class EmojiReactionRepositoryImpl @Inject constructor(
             reactionMessage.isEmojiReaction = true
             realm.insertOrUpdate(reactionMessage)
 
-            // Overwrite any previous reaction from this sender for this target
-            val priorFromSender = targetMessage.emojiReactions.filter { it.senderAddress == reaction.senderAddress }
+            // Overwrite any previous reaction from this same reactor for this target
+            val priorFromSender = targetMessage.emojiReactions.filter { sameReactor(it, reaction) }
             priorFromSender.forEach { it.deleteFromRealm() }
 
             targetMessage.emojiReactions.add(reaction)

--- a/data/src/main/java/com/moez/QKSMS/repository/MessageRepositoryImpl.kt
+++ b/data/src/main/java/com/moez/QKSMS/repository/MessageRepositoryImpl.kt
@@ -691,6 +691,43 @@ open class MessageRepositoryImpl @Inject constructor(
             ?.let { message -> sendMessage(message) }
             ?: listOf()
 
+    override fun sendReaction(
+        subId: Int, targetMessageId: Long, emoji: String, isRemoval: Boolean
+    ): Collection<Message> {
+        // Read the target's text/address and resolve the wire format up front
+        val target = getUnmanagedMessage(targetMessageId) ?: return listOf()
+        val targetText = target.getText(false)
+
+        val format = Realm.getDefaultInstance().use { realm ->
+            reactions.resolveFormat(target.threadId, realm)
+        }
+        val body = reactions.buildReactionBody(emoji, targetText, isRemoval, format)
+
+        // Send it through the normal pipeline (delivery, retry, etc. all handled)
+        val sent = sendNewMessages(subId, listOf(target.address), body, listOf(), false, 0)
+
+        // Hide the reaction message from the thread and record the reaction locally so it shows
+        // on the target bubble without waiting for a re-parse
+        Realm.getDefaultInstance().use { realm ->
+            realm.executeTransaction { r ->
+                val targetManaged = r.where(Message::class.java)
+                    .equalTo("id", targetMessageId).findFirst()
+                sent.forEach { msg ->
+                    val reactionManaged = r.where(Message::class.java)
+                        .equalTo("id", msg.id).findFirst() ?: return@forEach
+                    reactions.saveEmojiReaction(
+                        reactionManaged,
+                        ParsedEmojiReaction(emoji, targetText, isRemoval, format),
+                        targetManaged,
+                        r,
+                    )
+                }
+            }
+        }
+
+        return sent
+    }
+
     override fun cancelDelayedSmsAlarm(messageId: Long) =
         (context.getSystemService(Context.ALARM_SERVICE) as AlarmManager)
             .cancel(getIntentForDelayedSms(messageId))

--- a/data/src/main/java/com/moez/QKSMS/repository/MessageRepositoryImpl.kt
+++ b/data/src/main/java/com/moez/QKSMS/repository/MessageRepositoryImpl.kt
@@ -403,7 +403,7 @@ open class MessageRepositoryImpl @Inject constructor(
             }
             ?: 0
 
-    private fun syncProviderMessage(uri: Uri, sendAsGroup: Boolean): Message? {
+    private fun syncProviderMessage(uri: Uri, sendAsGroup: Boolean, asReaction: Boolean = false): Message? {
         // if uri doesn't have valid type
         val type = when {
             uri.toString().contains(TYPE_MMS) -> TYPE_MMS
@@ -428,6 +428,9 @@ open class MessageRepositoryImpl @Inject constructor(
 
             cursorToMessage.map(Pair(cursor, CursorToMessage.MessageColumns(cursor))).apply {
                 this.sendAsGroup = sendAsGroup
+                // mark reaction messages hidden before they're first committed, so the raw
+                // reaction bubble never flashes in the conversation
+                this.isEmojiReaction = asReaction
 
                 if (isMms()) {
                     parts = RealmList<MmsPart>().apply {
@@ -446,7 +449,7 @@ open class MessageRepositoryImpl @Inject constructor(
 
     override fun sendNewMessages(
         subId: Int, toAddresses: Collection<String>, body: String,
-        attachments: Collection<Attachment>, sendAsGroup: Boolean, delayMs: Int
+        attachments: Collection<Attachment>, sendAsGroup: Boolean, delayMs: Int, asReaction: Boolean
     ): Collection<Message> {
         Timber.v("sending message(s)")
 
@@ -606,7 +609,7 @@ open class MessageRepositoryImpl @Inject constructor(
             return listOf()
         }
 
-        val message = syncProviderMessage(messageUri, group)
+        val message = syncProviderMessage(messageUri, group, asReaction)
         if (message == null) {
             Timber.v("sync message failed for uri $messageUri")
             return listOf()
@@ -703,8 +706,9 @@ open class MessageRepositoryImpl @Inject constructor(
         }
         val body = reactions.buildReactionBody(emoji, targetText, isRemoval, format)
 
-        // Send it through the normal pipeline (delivery, retry, etc. all handled)
-        val sent = sendNewMessages(subId, listOf(target.address), body, listOf(), false, 0)
+        // Send it through the normal pipeline (delivery, retry, etc. all handled). asReaction hides
+        // the message from the moment it's created so the raw reaction text never flashes on screen.
+        val sent = sendNewMessages(subId, listOf(target.address), body, listOf(), false, 0, asReaction = true)
 
         // Hide the reaction message from the thread and record the reaction locally so it shows
         // on the target bubble without waiting for a re-parse

--- a/data/src/main/java/com/moez/QKSMS/util/EmojiPatternStrings.kt
+++ b/data/src/main/java/com/moez/QKSMS/util/EmojiPatternStrings.kt
@@ -25,4 +25,22 @@ data class EmojiPatternStrings(
 
     @Json(name = "emoji_reaction_ios_question_mark_added") val iosQuestionMarkAdded: String? = null,
     @Json(name = "emoji_reaction_ios_question_mark_removed") val iosQuestionMarkRemoved: String? = null,
+
+    // Forward templates used to *generate* outgoing iOS-readable reactions. "%1$s" is the emoji
+    // (generic template only) and the last "%s" is the target message text. When absent for a
+    // locale, English defaults are used.
+    @Json(name = "emoji_reaction_ios_generic_added_template") val iosGenericAddedTemplate: String? = null,
+    @Json(name = "emoji_reaction_ios_generic_removed_template") val iosGenericRemovedTemplate: String? = null,
+    @Json(name = "emoji_reaction_ios_heart_added_template") val iosHeartAddedTemplate: String? = null,
+    @Json(name = "emoji_reaction_ios_heart_removed_template") val iosHeartRemovedTemplate: String? = null,
+    @Json(name = "emoji_reaction_ios_like_added_template") val iosLikeAddedTemplate: String? = null,
+    @Json(name = "emoji_reaction_ios_like_removed_template") val iosLikeRemovedTemplate: String? = null,
+    @Json(name = "emoji_reaction_ios_dislike_added_template") val iosDislikeAddedTemplate: String? = null,
+    @Json(name = "emoji_reaction_ios_dislike_removed_template") val iosDislikeRemovedTemplate: String? = null,
+    @Json(name = "emoji_reaction_ios_laugh_added_template") val iosLaughAddedTemplate: String? = null,
+    @Json(name = "emoji_reaction_ios_laugh_removed_template") val iosLaughRemovedTemplate: String? = null,
+    @Json(name = "emoji_reaction_ios_exclamation_added_template") val iosExclamationAddedTemplate: String? = null,
+    @Json(name = "emoji_reaction_ios_exclamation_removed_template") val iosExclamationRemovedTemplate: String? = null,
+    @Json(name = "emoji_reaction_ios_question_mark_added_template") val iosQuestionMarkAddedTemplate: String? = null,
+    @Json(name = "emoji_reaction_ios_question_mark_removed_template") val iosQuestionMarkRemovedTemplate: String? = null,
 )

--- a/domain/src/main/java/com/moez/QKSMS/interactor/SendReaction.kt
+++ b/domain/src/main/java/com/moez/QKSMS/interactor/SendReaction.kt
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2025
+ *
+ * This file is part of QUIK.
+ *
+ * QUIK is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * QUIK is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with QUIK.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package dev.octoshrimpy.quik.interactor
+
+import dev.octoshrimpy.quik.repository.ConversationRepository
+import dev.octoshrimpy.quik.repository.MessageRepository
+import io.reactivex.Flowable
+import javax.inject.Inject
+
+class SendReaction @Inject constructor(
+    private val messageRepo: MessageRepository,
+    private val conversationRepo: ConversationRepository,
+) : Interactor<SendReaction.Params>() {
+
+    data class Params(
+        val subId: Int,
+        val targetMessageId: Long,
+        val emoji: String,
+        val isRemoval: Boolean = false,
+    )
+
+    override fun buildObservable(params: Params): Flowable<*> = Flowable.just(params)
+        .doOnNext {
+            val sent = messageRepo.sendReaction(
+                params.subId, params.targetMessageId, params.emoji, params.isRemoval
+            )
+            conversationRepo.updateConversations(sent.map { it.threadId }.distinct())
+        }
+}

--- a/domain/src/main/java/com/moez/QKSMS/model/EmojiReaction.kt
+++ b/domain/src/main/java/com/moez/QKSMS/model/EmojiReaction.kt
@@ -39,4 +39,20 @@ open class EmojiReaction : RealmObject() {
 
     /** Thread ID for easier querying */
     @Index var threadId: Long = 0
+
+    /** True if this reaction was sent by the local user from within Quik */
+    var fromMe: Boolean = false
+
+    /**
+     * The wire format that produced this reaction. One of [EmojiReaction.FORMAT_GOOGLE],
+     * [EmojiReaction.FORMAT_IOS_TAPBACK] or [EmojiReaction.FORMAT_IOS_GENERIC]. Used to
+     * auto-detect which format a recipient's messaging app understands.
+     */
+    var format: String = ""
+
+    companion object {
+        const val FORMAT_GOOGLE = "google"
+        const val FORMAT_IOS_TAPBACK = "ios_tapback"
+        const val FORMAT_IOS_GENERIC = "ios_generic"
+    }
 }

--- a/domain/src/main/java/com/moez/QKSMS/repository/EmojiReactionRepository.kt
+++ b/domain/src/main/java/com/moez/QKSMS/repository/EmojiReactionRepository.kt
@@ -21,12 +21,36 @@ package dev.octoshrimpy.quik.repository
 import dev.octoshrimpy.quik.model.Message
 import io.realm.Realm
 
-data class ParsedEmojiReaction(val emoji: String, val originalMessage: String, val isRemoval: Boolean = false)
+data class ParsedEmojiReaction(
+    val emoji: String,
+    val originalMessage: String,
+    val isRemoval: Boolean = false,
+    val format: String = "",
+)
 
 interface EmojiReactionRepository {
     fun parseEmojiReaction(body: String): ParsedEmojiReaction?
 
     fun findTargetMessage(threadId: Long, originalMessageText: String, realm: Realm): Message?
+
+    /**
+     * Builds the text body of an outgoing reaction message in the given wire [format], so that
+     * the recipient's messaging app can render it as a reaction. [format] is one of the
+     * `EmojiReaction.FORMAT_*` constants.
+     */
+    fun buildReactionBody(
+        emoji: String,
+        targetText: String,
+        isRemoval: Boolean,
+        format: String,
+    ): String
+
+    /**
+     * Determines the best wire format to use when sending a reaction to the given thread. Honours
+     * the user's send-format preference; when set to auto, mirrors the format last received in the
+     * thread, falling back to the Google Messages format.
+     */
+    fun resolveFormat(threadId: Long, realm: Realm): String
 
     fun saveEmojiReaction(
         reactionMessage: Message,

--- a/domain/src/main/java/com/moez/QKSMS/repository/MessageRepository.kt
+++ b/domain/src/main/java/com/moez/QKSMS/repository/MessageRepository.kt
@@ -86,7 +86,8 @@ interface MessageRepository {
 
     fun sendNewMessages(
         subId: Int, toAddresses: Collection<String>, body: String,
-        attachments: Collection<Attachment>, sendAsGroup: Boolean, delayMs: Int = 0
+        attachments: Collection<Attachment>, sendAsGroup: Boolean, delayMs: Int = 0,
+        asReaction: Boolean = false
     ): Collection<Message>
 
     fun sendMessage(message: Message): Collection<Message>

--- a/domain/src/main/java/com/moez/QKSMS/repository/MessageRepository.kt
+++ b/domain/src/main/java/com/moez/QKSMS/repository/MessageRepository.kt
@@ -93,6 +93,15 @@ interface MessageRepository {
 
     fun sendMessage(messageId: Long): Collection<Message>
 
+    /**
+     * Sends an emoji reaction to the message with id [targetMessageId]. The reaction is sent as a
+     * specially-formatted text message (see [EmojiReactionRepository.buildReactionBody]) and is also
+     * recorded locally so it renders immediately. When [isRemoval] is true, an un-react is sent.
+     */
+    fun sendReaction(
+        subId: Int, targetMessageId: Long, emoji: String, isRemoval: Boolean
+    ): Collection<Message>
+
     fun cancelDelayedSmsAlarm(messageId: Long)
 
     fun insertReceivedSms(subId: Int, address: String, body: String, sentTime: Long): Message

--- a/domain/src/main/java/com/moez/QKSMS/util/Preferences.kt
+++ b/domain/src/main/java/com/moez/QKSMS/util/Preferences.kt
@@ -84,6 +84,18 @@ class Preferences @Inject constructor(
         const val MESSAGE_LINK_HANDLING_BLOCK = 0
         const val MESSAGE_LINK_HANDLING_ALLOW = 1
         const val MESSAGE_LINK_HANDLING_ASK = 2
+
+        // Wire format used when sending an emoji reaction
+        const val REACTION_FORMAT_AUTO = 0
+        const val REACTION_FORMAT_GOOGLE = 1
+        const val REACTION_FORMAT_IOS = 2
+
+        // Which gesture triggers the reaction picker (the other triggers multi-select)
+        const val REACTION_GESTURE_LONG_PRESS = 0
+        const val REACTION_GESTURE_DOUBLE_TAP = 1
+
+        // Maximum number of recently-used emojis remembered for the reaction picker
+        const val REACTION_RECENTS_MAX = 3
     }
 
     // Internal
@@ -99,6 +111,11 @@ class Preferences @Inject constructor(
 
     // User configurable
     val sendAsGroup = rxPrefs.getBoolean("sendAsGroup", true)
+
+    // Emoji reactions
+    val reactionSendFormat = rxPrefs.getInteger("reactionSendFormat", REACTION_FORMAT_AUTO)
+    val reactionGesture = rxPrefs.getInteger("reactionGesture", REACTION_GESTURE_LONG_PRESS)
+    val reactionRecents = rxPrefs.getString("reactionRecents", "")
     val nightMode = rxPrefs.getInteger("nightMode", when (Build.VERSION.SDK_INT >= 29) {
         true -> NIGHT_MODE_SYSTEM
         false -> NIGHT_MODE_OFF

--- a/domain/src/main/java/com/moez/QKSMS/util/Preferences.kt
+++ b/domain/src/main/java/com/moez/QKSMS/util/Preferences.kt
@@ -94,8 +94,12 @@ class Preferences @Inject constructor(
         const val REACTION_GESTURE_LONG_PRESS = 0
         const val REACTION_GESTURE_DOUBLE_TAP = 1
 
-        // Maximum number of recently-used emojis remembered for the reaction picker
-        const val REACTION_RECENTS_MAX = 3
+        // Default number of recently-used emojis shown in the reaction picker
+        const val REACTION_RECENTS_DEFAULT = 3
+
+        // How many recently-used emojis we persist (>= the largest selectable display count) so
+        // history survives when the user increases the display count
+        const val REACTION_RECENTS_STORE_MAX = 10
     }
 
     // Internal
@@ -116,6 +120,7 @@ class Preferences @Inject constructor(
     val reactionSendFormat = rxPrefs.getInteger("reactionSendFormat", REACTION_FORMAT_AUTO)
     val reactionGesture = rxPrefs.getInteger("reactionGesture", REACTION_GESTURE_LONG_PRESS)
     val reactionRecents = rxPrefs.getString("reactionRecents", "")
+    val reactionRecentsCount = rxPrefs.getInteger("reactionRecentsCount", REACTION_RECENTS_DEFAULT)
     val nightMode = rxPrefs.getInteger("nightMode", when (Build.VERSION.SDK_INT >= 29) {
         true -> NIGHT_MODE_SYSTEM
         false -> NIGHT_MODE_OFF

--- a/presentation/build.gradle
+++ b/presentation/build.gradle
@@ -120,6 +120,7 @@ dependencies {
     // androidx
     implementation "androidx.appcompat:appcompat:$androidx_appcompat_version"
     implementation "androidx.emoji2:emoji2-bundled:$androidx_emoji2_version"
+    implementation "androidx.emoji2:emoji2-emojipicker:$androidx_emoji2_version"
     implementation "androidx.constraintlayout:constraintlayout:$androidx_constraintlayout_version"
     implementation "androidx.core:core-ktx:$androidx_core_version"
     implementation "androidx.viewpager2:viewpager2:$androidx_viewpager_version"

--- a/presentation/src/main/java/com/moez/QKSMS/common/base/QkRealmAdapter.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/common/base/QkRealmAdapter.kt
@@ -86,6 +86,9 @@ abstract class QkRealmAdapter<T : RealmModel, VH : QkViewHolder> : RealmRecycler
         return selection.contains(id)
     }
 
+    /** True when one or more items are selected (ie. the user is in multi-select mode) */
+    protected fun isSelectionMode(): Boolean = selection.isNotEmpty()
+
     fun clearSelection() {
         selection.clear()
         selectionChanges.onNext(selection)

--- a/presentation/src/main/java/com/moez/QKSMS/feature/compose/ComposeActivity.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/feature/compose/ComposeActivity.kt
@@ -22,6 +22,7 @@ import android.Manifest
 import android.animation.LayoutTransition
 import android.app.Activity
 import android.app.DatePickerDialog
+import android.app.Dialog
 import android.app.TimePickerDialog
 import android.content.ActivityNotFoundException
 import android.content.ContentValues
@@ -36,8 +37,6 @@ import android.provider.ContactsContract
 import android.provider.MediaStore
 import android.speech.RecognizerIntent
 import android.speech.SpeechRecognizer
-import android.text.Editable
-import android.text.TextWatcher
 import android.text.format.DateFormat
 import android.view.ContextMenu
 import android.view.DragEvent.ACTION_DRAG_ENDED
@@ -46,9 +45,11 @@ import android.view.DragEvent.ACTION_DROP
 import android.view.Gravity
 import android.view.Menu
 import android.view.MenuItem
+import android.view.MotionEvent
 import android.view.View
+import android.view.ViewGroup
 import android.view.WindowManager
-import android.widget.EditText
+import android.widget.FrameLayout
 import android.widget.LinearLayout
 import android.widget.PopupWindow
 import android.widget.SeekBar
@@ -59,6 +60,7 @@ import androidx.constraintlayout.widget.ConstraintSet
 import androidx.core.app.ActivityCompat
 import androidx.core.content.ContextCompat
 import androidx.core.view.isVisible
+import androidx.emoji2.emojipicker.EmojiPickerView
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.ViewModelProviders
 import com.google.android.flexbox.FlexboxLayout
@@ -101,7 +103,6 @@ import io.reactivex.schedulers.Schedulers
 import dev.octoshrimpy.quik.databinding.ComposeActivityBinding
 import io.reactivex.subjects.PublishSubject
 import io.reactivex.subjects.Subject
-import java.text.BreakIterator
 import java.text.SimpleDateFormat
 import java.util.Calendar
 import java.util.Date
@@ -873,46 +874,77 @@ class ComposeActivity : QkThemedActivity(), ComposeView {
     }
 
     private fun promptForCustomEmoji(messageId: Long) {
-        val input = EditText(this).apply {
-            hint = getString(R.string.compose_reaction_emoji_hint)
-            setSingleLine()
-        }
+        // Show a full emoji grid picker (categorised, tracks its own recents) rather than relying on
+        // the system keyboard's emoji tab, which can't be opened programmatically. EmojiPickerView
+        // needs a Material3 theme for its colours, and a plain fixed-height dialog (rather than a
+        // bottom sheet) gives its internal grid an unambiguous bounded viewport so it scrolls.
+        val dialog = Dialog(this, R.style.ReactionEmojiPickerTheme)
+        val drawerHeight = (resources.displayMetrics.heightPixels * 0.7).toInt()
 
-        val dialog = AlertDialog.Builder(this)
-            .setTitle(R.string.compose_reaction_custom_title)
-            .setView(input)
-            .setNegativeButton(R.string.button_cancel, null)
-            .create()
-
-        // pop the keyboard automatically so the user can type an emoji straight away
-        dialog.window?.setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_STATE_ALWAYS_VISIBLE)
-
-        // submit automatically as soon as an emoji is typed, then dismiss
-        input.addTextChangedListener(object : TextWatcher {
-            override fun beforeTextChanged(s: CharSequence?, start: Int, count: Int, after: Int) {}
-            override fun onTextChanged(s: CharSequence?, start: Int, before: Int, count: Int) {}
-            override fun afterTextChanged(s: Editable?) {
-                val emoji = firstEmoji(s?.toString() ?: "") ?: return
-                input.removeTextChangedListener(this)
-                reactionSelectedIntent.onNext(messageId to emoji)
-                rememberRecentEmoji(emoji)
+        val picker = EmojiPickerView(dialog.context).apply {
+            // opaque surface background since the window itself is transparent
+            setBackgroundColor(dialog.context.resolveThemeColor(com.google.android.material.R.attr.colorSurface))
+            setOnEmojiPickedListener { item ->
+                reactionSelectedIntent.onNext(messageId to item.emoji)
+                rememberRecentEmoji(item.emoji)
                 dialog.dismiss()
             }
-        })
+        }
 
+        // Full-screen root: a dim scrim with the drawer pinned to the bottom. A gesture that begins
+        // above the drawer is captured here (so it dismisses even if it travels down into the
+        // drawer), while a gesture that begins inside the drawer falls through to the grid so it
+        // scrolls.
+        val root = object : FrameLayout(dialog.context) {
+            override fun onInterceptTouchEvent(ev: MotionEvent): Boolean =
+                ev.actionMasked == MotionEvent.ACTION_DOWN && ev.y < picker.top
+
+            override fun onTouchEvent(ev: MotionEvent): Boolean {
+                if (ev.actionMasked == MotionEvent.ACTION_UP) dialog.dismiss()
+                return true
+            }
+        }.apply {
+            setBackgroundColor(0x80000000.toInt())
+            addView(
+                picker,
+                FrameLayout.LayoutParams(
+                    FrameLayout.LayoutParams.MATCH_PARENT, drawerHeight, Gravity.BOTTOM
+                )
+            )
+        }
+
+        dialog.setContentView(
+            root,
+            ViewGroup.LayoutParams(
+                ViewGroup.LayoutParams.MATCH_PARENT,
+                ViewGroup.LayoutParams.MATCH_PARENT
+            )
+        )
+        dialog.window?.setLayout(
+            ViewGroup.LayoutParams.MATCH_PARENT,
+            ViewGroup.LayoutParams.MATCH_PARENT
+        )
+        // The full-screen dialog window would otherwise recolour the system bars (in light mode it
+        // left white icons on the white status bar). Once shown, take control of the system bar
+        // backgrounds and copy the activity's bar colours + light/dark icon appearance so they look
+        // unchanged. Done in onShow so the window is attached and the appearance flag actually sticks.
+        dialog.setOnShowListener {
+            dialog.window?.let { dialogWindow ->
+                dialogWindow.clearFlags(
+                    WindowManager.LayoutParams.FLAG_TRANSLUCENT_STATUS or
+                            WindowManager.LayoutParams.FLAG_TRANSLUCENT_NAVIGATION
+                )
+                dialogWindow.addFlags(WindowManager.LayoutParams.FLAG_DRAWS_SYSTEM_BAR_BACKGROUNDS)
+                dialogWindow.statusBarColor = window.statusBarColor
+                dialogWindow.navigationBarColor = window.navigationBarColor
+                // QkThemedActivity drives the light/dark status-bar icons via the legacy
+                // systemUiVisibility flags (not WindowInsetsController), so copy those verbatim to
+                // keep the dialog's icons matching the activity in both light and dark mode.
+                @Suppress("DEPRECATION")
+                run { dialogWindow.decorView.systemUiVisibility = window.decorView.systemUiVisibility }
+            }
+        }
         dialog.show()
-        input.requestFocus()
-    }
-
-    /** Returns the first grapheme cluster (which handles multi-codepoint emoji) of [text], or null */
-    private fun firstEmoji(text: String): String? {
-        val trimmed = text.trim()
-        if (trimmed.isEmpty()) return null
-
-        val iterator = BreakIterator.getCharacterInstance()
-        iterator.setText(trimmed)
-        val end = iterator.next()
-        return if (end == BreakIterator.DONE) trimmed else trimmed.substring(0, end)
     }
 
     override fun onCreateOptionsMenu(menu: Menu?): Boolean {

--- a/presentation/src/main/java/com/moez/QKSMS/feature/compose/ComposeActivity.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/feature/compose/ComposeActivity.kt
@@ -27,6 +27,7 @@ import android.content.ActivityNotFoundException
 import android.content.ContentValues
 import android.content.Intent
 import android.content.res.ColorStateList
+import android.graphics.drawable.GradientDrawable
 import android.net.Uri
 import android.os.Build
 import android.os.Bundle
@@ -40,10 +41,15 @@ import android.view.ContextMenu
 import android.view.DragEvent.ACTION_DRAG_ENDED
 import android.view.DragEvent.ACTION_DRAG_EXITED
 import android.view.DragEvent.ACTION_DROP
+import android.view.Gravity
 import android.view.Menu
 import android.view.MenuItem
 import android.view.View
+import android.widget.EditText
+import android.widget.LinearLayout
+import android.widget.PopupWindow
 import android.widget.SeekBar
+import android.widget.TextView
 import android.widget.Toast
 import androidx.appcompat.app.AlertDialog
 import androidx.constraintlayout.widget.ConstraintSet
@@ -69,17 +75,21 @@ import dev.octoshrimpy.quik.common.util.extensions.autoScrollToStart
 import dev.octoshrimpy.quik.common.util.extensions.dpToPx
 import dev.octoshrimpy.quik.common.util.extensions.hideKeyboard
 import dev.octoshrimpy.quik.common.util.extensions.makeToast
+import dev.octoshrimpy.quik.common.util.extensions.resolveThemeColor
 import dev.octoshrimpy.quik.common.util.extensions.scrapViews
 import dev.octoshrimpy.quik.common.util.extensions.setBackgroundTint
 import dev.octoshrimpy.quik.common.util.extensions.setTint
 import dev.octoshrimpy.quik.common.util.extensions.setVisible
 import dev.octoshrimpy.quik.common.util.extensions.showKeyboard
 import dev.octoshrimpy.quik.common.widget.MicInputCloudView
+import dev.octoshrimpy.quik.common.widget.QkContextMenuRecyclerView
 import dev.octoshrimpy.quik.extensions.mapNotNull
 import dev.octoshrimpy.quik.feature.compose.editing.ChipsAdapter
 import dev.octoshrimpy.quik.feature.contacts.ContactsActivity
 import dev.octoshrimpy.quik.model.Attachment
+import dev.octoshrimpy.quik.model.MmsPart
 import dev.octoshrimpy.quik.model.Recipient
+import dev.octoshrimpy.quik.util.Preferences
 import io.reactivex.Observable
 import io.reactivex.android.schedulers.AndroidSchedulers
 import io.reactivex.disposables.Disposable
@@ -87,6 +97,7 @@ import io.reactivex.schedulers.Schedulers
 import dev.octoshrimpy.quik.databinding.ComposeActivityBinding
 import io.reactivex.subjects.PublishSubject
 import io.reactivex.subjects.Subject
+import java.text.BreakIterator
 import java.text.SimpleDateFormat
 import java.util.Calendar
 import java.util.Date
@@ -105,6 +116,11 @@ class ComposeActivity : QkThemedActivity(), ComposeView {
     @Inject lateinit var viewModelFactory: ViewModelProvider.Factory
 
     private lateinit var binding: ComposeActivityBinding
+
+    // the currently-showing floating emoji reaction picker, if any
+    private var reactionPopup: PopupWindow? = null
+    // the media part view last long-pressed, used to anchor the reaction picker for media messages
+    private var partContextMenuAnchor: View? = null
 
     override val activityVisibleIntent: Subject<Boolean> = PublishSubject.create()
     override val chipsSelectedIntent: Subject<HashMap<String, String?>> = PublishSubject.create()
@@ -141,6 +157,7 @@ class ComposeActivity : QkThemedActivity(), ComposeView {
     override val clearCurrentMessageIntent: Subject<Boolean> = PublishSubject.create()
     override val messageLinkAskIntent: Subject<Uri> by lazy { messageAdapter.messageLinkClicks }
     override val reactionClickIntent: Subject<Long> by lazy { messageAdapter.reactionClicks }
+    override val reactionSelectedIntent: Subject<Pair<Long, String>> = PublishSubject.create()
     override val speechRecogniserIntent by lazy { binding.speechToTextIcon.clicks() }
     override val shadeIntent by lazy { binding.shadeBackground.clicks() }
     override val recordAudioStartStopRecording: Subject<Boolean> = PublishSubject.create()
@@ -244,6 +261,11 @@ class ComposeActivity : QkThemedActivity(), ComposeView {
                 .mapNotNull { it }
                 .autoDisposable(scope())
                 .subscribe { registerForContextMenu(it) }
+
+            // show the floating emoji reaction picker when a message asks to be reacted to
+            messageAdapter.reactionBarClicks
+                .autoDisposable(scope())
+                .subscribe { (messageId, anchor) -> showReactionPicker(messageId, anchor) }
 
             // drag drop handlers for speech-to-text icon
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
@@ -385,6 +407,10 @@ class ComposeActivity : QkThemedActivity(), ComposeView {
     override fun onPause() {
         super.onPause()
         activityVisibleIntent.onNext(false)
+
+        // avoid leaking the reaction picker window if we're backgrounded while it's open
+        reactionPopup?.dismiss()
+        reactionPopup = null
     }
 
     override fun onDestroy() {
@@ -716,6 +742,124 @@ class ComposeActivity : QkThemedActivity(), ComposeView {
             .show()
     }
 
+    /** The six standard tapback reactions, always shown first in the picker */
+    private val standardReactionEmojis = listOf("❤️", "👍", "👎", "😂", "‼️", "❓")
+
+    /**
+     * Shows the floating emoji reaction picker above [anchor]. Picking an emoji emits it on
+     * [reactionSelectedIntent] for the view model to send.
+     */
+    private fun showReactionPicker(messageId: Long, anchor: View) {
+        reactionPopup?.dismiss()
+
+        val content = layoutInflater.inflate(R.layout.reaction_bar, binding.root, false) as LinearLayout
+
+        // tint the picker to match the current theme
+        (content.background?.mutate() as? GradientDrawable)
+            ?.setColor(resolveThemeColor(android.R.attr.windowBackground))
+
+        val onPicked = { emoji: String ->
+            reactionSelectedIntent.onNext(messageId to emoji)
+            rememberRecentEmoji(emoji)
+            reactionPopup?.dismiss()
+        }
+
+        reactionPickerEmojis().forEach { emoji ->
+            content.addView((layoutInflater.inflate(R.layout.reaction_bar_emoji, content, false) as TextView)
+                .apply {
+                    text = emoji
+                    setOnClickListener { onPicked(emoji) }
+                })
+        }
+
+        // the '+' opens the full system emoji keyboard so any emoji can be used
+        content.addView((layoutInflater.inflate(R.layout.reaction_bar_emoji, content, false) as TextView)
+            .apply {
+                text = "+"
+                setOnClickListener {
+                    reactionPopup?.dismiss()
+                    promptForCustomEmoji(messageId)
+                }
+            })
+
+        val popup = PopupWindow(
+            content,
+            LinearLayout.LayoutParams.WRAP_CONTENT,
+            LinearLayout.LayoutParams.WRAP_CONTENT,
+            true
+        ).apply {
+            isOutsideTouchable = true
+            elevation = resources.displayMetrics.density * 8
+        }
+
+        content.measure(
+            View.MeasureSpec.makeMeasureSpec(0, View.MeasureSpec.UNSPECIFIED),
+            View.MeasureSpec.makeMeasureSpec(0, View.MeasureSpec.UNSPECIFIED)
+        )
+        val location = IntArray(2)
+        anchor.getLocationInWindow(location)
+        val x = location[0] + anchor.width / 2 - content.measuredWidth / 2
+        val y = location[1] - content.measuredHeight
+
+        popup.showAtLocation(anchor, Gravity.NO_GRAVITY, x.coerceAtLeast(0), y.coerceAtLeast(0))
+        reactionPopup = popup
+    }
+
+    /** Standard tapbacks followed by up to [Preferences.REACTION_RECENTS_MAX] recent emojis */
+    private fun reactionPickerEmojis(): List<String> {
+        val recents = recentEmojis()
+            .filter { it !in standardReactionEmojis }
+            .take(Preferences.REACTION_RECENTS_MAX)
+        return standardReactionEmojis + recents
+    }
+
+    private fun recentEmojis(): List<String> =
+        prefs.reactionRecents.get()
+            .split("\n")
+            .map { it.trim() }
+            .filter { it.isNotEmpty() }
+
+    private fun rememberRecentEmoji(emoji: String) {
+        // the standard tapbacks are always shown, so don't waste a recents slot on them
+        if (emoji in standardReactionEmojis) return
+
+        val updated = (listOf(emoji) + recentEmojis().filter { it != emoji })
+            .take(Preferences.REACTION_RECENTS_MAX)
+        prefs.reactionRecents.set(updated.joinToString("\n"))
+    }
+
+    private fun promptForCustomEmoji(messageId: Long) {
+        val input = EditText(this).apply {
+            hint = getString(R.string.compose_reaction_emoji_hint)
+            setSingleLine()
+        }
+
+        AlertDialog.Builder(this)
+            .setTitle(R.string.compose_reaction_custom_title)
+            .setView(input)
+            .setPositiveButton(R.string.button_continue) { _, _ ->
+                firstEmoji(input.text.toString())?.let { emoji ->
+                    reactionSelectedIntent.onNext(messageId to emoji)
+                    rememberRecentEmoji(emoji)
+                }
+            }
+            .setNegativeButton(R.string.button_cancel, null)
+            .show()
+
+        input.requestFocus()
+    }
+
+    /** Returns the first grapheme cluster (which handles multi-codepoint emoji) of [text], or null */
+    private fun firstEmoji(text: String): String? {
+        val trimmed = text.trim()
+        if (trimmed.isEmpty()) return null
+
+        val iterator = BreakIterator.getCharacterInstance()
+        iterator.setText(trimmed)
+        val end = iterator.next()
+        return if (end == BreakIterator.DONE) trimmed else trimmed.substring(0, end)
+    }
+
     override fun onCreateOptionsMenu(menu: Menu?): Boolean {
         menuInflater.inflate(R.menu.compose, menu)
         return super.onCreateOptionsMenu(menu)
@@ -736,11 +880,24 @@ class ComposeActivity : QkThemedActivity(), ComposeView {
         menuInfo: ContextMenu.ContextMenuInfo?
     ) {
         super.onCreateContextMenu(menu, v, menuInfo)
+        // remember the touched part view so the reaction picker can anchor to it
+        partContextMenuAnchor = v
         menuInflater.inflate(R.menu.mms_part_menu, menu)
     }
 
     override fun onContextItemSelected(item: MenuItem): Boolean {
         super.onContextItemSelected(item)
+
+        // reacting to a media part is a pure UI action; handle it here (anchored to the part view)
+        if (item.itemId == R.id.reactToPart) {
+            @Suppress("UNCHECKED_CAST")
+            val menuInfo = item.menuInfo as? QkContextMenuRecyclerView.ContextMenuInfo<Long, MmsPart>
+            val messageId = menuInfo?.viewHolderValue?.messageId
+            val anchor = partContextMenuAnchor ?: binding.messageList
+            if (messageId != null) showReactionPicker(messageId, anchor)
+            return true
+        }
+
         contextItemIntent.onNext(item)
         return true
     }

--- a/presentation/src/main/java/com/moez/QKSMS/feature/compose/ComposeActivity.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/feature/compose/ComposeActivity.kt
@@ -36,6 +36,8 @@ import android.provider.ContactsContract
 import android.provider.MediaStore
 import android.speech.RecognizerIntent
 import android.speech.SpeechRecognizer
+import android.text.Editable
+import android.text.TextWatcher
 import android.text.format.DateFormat
 import android.view.ContextMenu
 import android.view.DragEvent.ACTION_DRAG_ENDED
@@ -45,7 +47,9 @@ import android.view.Gravity
 import android.view.Menu
 import android.view.MenuItem
 import android.view.View
+import android.view.WindowManager
 import android.widget.EditText
+import android.widget.HorizontalScrollView
 import android.widget.LinearLayout
 import android.widget.PopupWindow
 import android.widget.SeekBar
@@ -752,39 +756,53 @@ class ComposeActivity : QkThemedActivity(), ComposeView {
     private fun showReactionPicker(messageId: Long, anchor: View) {
         reactionPopup?.dismiss()
 
-        val content = layoutInflater.inflate(R.layout.reaction_bar, binding.root, false) as LinearLayout
+        val root = layoutInflater.inflate(R.layout.reaction_bar, binding.root, false) as LinearLayout
+        val scroll = root.findViewById<HorizontalScrollView>(R.id.reactionScroll)
+        val container = root.findViewById<LinearLayout>(R.id.reactionBarContainer)
+        val plus = root.findViewById<TextView>(R.id.reactionPlus)
 
         // tint the picker to match the current theme
-        (content.background?.mutate() as? GradientDrawable)
+        (root.background?.mutate() as? GradientDrawable)
             ?.setColor(resolveThemeColor(android.R.attr.windowBackground))
 
-        val onPicked = { emoji: String ->
-            reactionSelectedIntent.onNext(messageId to emoji)
-            rememberRecentEmoji(emoji)
-            reactionPopup?.dismiss()
-        }
-
         reactionPickerEmojis().forEach { emoji ->
-            content.addView((layoutInflater.inflate(R.layout.reaction_bar_emoji, content, false) as TextView)
+            container.addView((layoutInflater.inflate(R.layout.reaction_bar_emoji, container, false) as TextView)
                 .apply {
                     text = emoji
-                    setOnClickListener { onPicked(emoji) }
+                    setOnClickListener {
+                        reactionSelectedIntent.onNext(messageId to emoji)
+                        rememberRecentEmoji(emoji)
+                        reactionPopup?.dismiss()
+                    }
                 })
         }
 
-        // the '+' opens the full system emoji keyboard so any emoji can be used
-        content.addView((layoutInflater.inflate(R.layout.reaction_bar_emoji, content, false) as TextView)
-            .apply {
-                text = "+"
-                setOnClickListener {
-                    reactionPopup?.dismiss()
-                    promptForCustomEmoji(messageId)
-                }
-            })
+        // the pinned '+' opens the full system emoji keyboard so any emoji can be used
+        plus.setOnClickListener {
+            reactionPopup?.dismiss()
+            promptForCustomEmoji(messageId)
+        }
+
+        val margin = (resources.displayMetrics.density * 8).toInt()
+        val screenWidth = resources.displayMetrics.widthPixels
+        val available = screenWidth - (2 * margin)
+
+        // measure the natural size; if the row is wider than the screen, cap the popup to the
+        // available width and let the emoji list scroll while the '+' stays pinned
+        root.measure(
+            View.MeasureSpec.makeMeasureSpec(0, View.MeasureSpec.UNSPECIFIED),
+            View.MeasureSpec.makeMeasureSpec(0, View.MeasureSpec.UNSPECIFIED)
+        )
+        val overflows = root.measuredWidth > available
+        if (overflows) {
+            scroll.layoutParams = LinearLayout.LayoutParams(0, LinearLayout.LayoutParams.WRAP_CONTENT, 1f)
+        }
+        val shownWidth = if (overflows) available else root.measuredWidth
+        val popupWidth = if (overflows) available else LinearLayout.LayoutParams.WRAP_CONTENT
 
         val popup = PopupWindow(
-            content,
-            LinearLayout.LayoutParams.WRAP_CONTENT,
+            root,
+            popupWidth,
             LinearLayout.LayoutParams.WRAP_CONTENT,
             true
         ).apply {
@@ -792,16 +810,13 @@ class ComposeActivity : QkThemedActivity(), ComposeView {
             elevation = resources.displayMetrics.density * 8
         }
 
-        content.measure(
-            View.MeasureSpec.makeMeasureSpec(0, View.MeasureSpec.UNSPECIFIED),
-            View.MeasureSpec.makeMeasureSpec(0, View.MeasureSpec.UNSPECIFIED)
-        )
         val location = IntArray(2)
         anchor.getLocationInWindow(location)
-        val x = location[0] + anchor.width / 2 - content.measuredWidth / 2
-        val y = location[1] - content.measuredHeight
+        val x = (location[0] + anchor.width / 2 - shownWidth / 2)
+            .coerceIn(margin, (screenWidth - shownWidth - margin).coerceAtLeast(margin))
+        val y = (location[1] - root.measuredHeight).coerceAtLeast(0)
 
-        popup.showAtLocation(anchor, Gravity.NO_GRAVITY, x.coerceAtLeast(0), y.coerceAtLeast(0))
+        popup.showAtLocation(anchor, Gravity.NO_GRAVITY, x, y)
         reactionPopup = popup
     }
 
@@ -834,18 +849,29 @@ class ComposeActivity : QkThemedActivity(), ComposeView {
             setSingleLine()
         }
 
-        AlertDialog.Builder(this)
+        val dialog = AlertDialog.Builder(this)
             .setTitle(R.string.compose_reaction_custom_title)
             .setView(input)
-            .setPositiveButton(R.string.button_continue) { _, _ ->
-                firstEmoji(input.text.toString())?.let { emoji ->
-                    reactionSelectedIntent.onNext(messageId to emoji)
-                    rememberRecentEmoji(emoji)
-                }
-            }
             .setNegativeButton(R.string.button_cancel, null)
-            .show()
+            .create()
 
+        // pop the keyboard automatically so the user can type an emoji straight away
+        dialog.window?.setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_STATE_ALWAYS_VISIBLE)
+
+        // submit automatically as soon as an emoji is typed, then dismiss
+        input.addTextChangedListener(object : TextWatcher {
+            override fun beforeTextChanged(s: CharSequence?, start: Int, count: Int, after: Int) {}
+            override fun onTextChanged(s: CharSequence?, start: Int, before: Int, count: Int) {}
+            override fun afterTextChanged(s: Editable?) {
+                val emoji = firstEmoji(s?.toString() ?: "") ?: return
+                input.removeTextChangedListener(this)
+                reactionSelectedIntent.onNext(messageId to emoji)
+                rememberRecentEmoji(emoji)
+                dialog.dismiss()
+            }
+        })
+
+        dialog.show()
         input.requestFocus()
     }
 

--- a/presentation/src/main/java/com/moez/QKSMS/feature/compose/ComposeActivity.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/feature/compose/ComposeActivity.kt
@@ -49,7 +49,6 @@ import android.view.MenuItem
 import android.view.View
 import android.view.WindowManager
 import android.widget.EditText
-import android.widget.HorizontalScrollView
 import android.widget.LinearLayout
 import android.widget.PopupWindow
 import android.widget.SeekBar
@@ -62,6 +61,7 @@ import androidx.core.content.ContextCompat
 import androidx.core.view.isVisible
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.ViewModelProviders
+import com.google.android.flexbox.FlexboxLayout
 import com.google.android.flexbox.FlexboxLayoutManager
 import com.google.android.material.snackbar.Snackbar
 import com.jakewharton.rxbinding2.view.clicks
@@ -756,13 +756,10 @@ class ComposeActivity : QkThemedActivity(), ComposeView {
     private fun showReactionPicker(messageId: Long, anchor: View) {
         reactionPopup?.dismiss()
 
-        val root = layoutInflater.inflate(R.layout.reaction_bar, binding.root, false) as LinearLayout
-        val scroll = root.findViewById<HorizontalScrollView>(R.id.reactionScroll)
-        val container = root.findViewById<LinearLayout>(R.id.reactionBarContainer)
-        val plus = root.findViewById<TextView>(R.id.reactionPlus)
+        val container = layoutInflater.inflate(R.layout.reaction_bar, binding.root, false) as FlexboxLayout
 
         // tint the picker to match the current theme
-        (root.background?.mutate() as? GradientDrawable)
+        (container.background?.mutate() as? GradientDrawable)
             ?.setColor(resolveThemeColor(android.R.attr.windowBackground))
 
         reactionPickerEmojis().forEach { emoji ->
@@ -777,32 +774,30 @@ class ComposeActivity : QkThemedActivity(), ComposeView {
                 })
         }
 
-        // the pinned '+' opens the full system emoji keyboard so any emoji can be used
-        plus.setOnClickListener {
-            reactionPopup?.dismiss()
-            promptForCustomEmoji(messageId)
-        }
+        // the '+' opens the full system emoji keyboard so any emoji can be used
+        container.addView((layoutInflater.inflate(R.layout.reaction_bar_emoji, container, false) as TextView)
+            .apply {
+                text = "+"
+                setOnClickListener {
+                    reactionPopup?.dismiss()
+                    promptForCustomEmoji(messageId)
+                }
+            })
 
         val margin = (resources.displayMetrics.density * 8).toInt()
         val screenWidth = resources.displayMetrics.widthPixels
         val available = screenWidth - (2 * margin)
 
-        // measure the natural size; if the row is wider than the screen, cap the popup to the
-        // available width and let the emoji list scroll while the '+' stays pinned
-        root.measure(
-            View.MeasureSpec.makeMeasureSpec(0, View.MeasureSpec.UNSPECIFIED),
+        // constrain to the available width so the flexbox wraps onto multiple lines when needed
+        container.measure(
+            View.MeasureSpec.makeMeasureSpec(available, View.MeasureSpec.AT_MOST),
             View.MeasureSpec.makeMeasureSpec(0, View.MeasureSpec.UNSPECIFIED)
         )
-        val overflows = root.measuredWidth > available
-        if (overflows) {
-            scroll.layoutParams = LinearLayout.LayoutParams(0, LinearLayout.LayoutParams.WRAP_CONTENT, 1f)
-        }
-        val shownWidth = if (overflows) available else root.measuredWidth
-        val popupWidth = if (overflows) available else LinearLayout.LayoutParams.WRAP_CONTENT
+        val shownWidth = container.measuredWidth
 
         val popup = PopupWindow(
-            root,
-            popupWidth,
+            container,
+            shownWidth,
             LinearLayout.LayoutParams.WRAP_CONTENT,
             true
         ).apply {
@@ -814,17 +809,18 @@ class ComposeActivity : QkThemedActivity(), ComposeView {
         anchor.getLocationInWindow(location)
         val x = (location[0] + anchor.width / 2 - shownWidth / 2)
             .coerceIn(margin, (screenWidth - shownWidth - margin).coerceAtLeast(margin))
-        val y = (location[1] - root.measuredHeight).coerceAtLeast(0)
+        val y = (location[1] - container.measuredHeight).coerceAtLeast(0)
 
         popup.showAtLocation(anchor, Gravity.NO_GRAVITY, x, y)
         reactionPopup = popup
     }
 
-    /** Standard tapbacks followed by up to [Preferences.REACTION_RECENTS_MAX] recent emojis */
+    /** Standard tapbacks followed by up to the user's configured number of recent emojis */
     private fun reactionPickerEmojis(): List<String> {
+        val count = prefs.reactionRecentsCount.get().coerceAtLeast(0)
         val recents = recentEmojis()
             .filter { it !in standardReactionEmojis }
-            .take(Preferences.REACTION_RECENTS_MAX)
+            .take(count)
         return standardReactionEmojis + recents
     }
 
@@ -839,7 +835,7 @@ class ComposeActivity : QkThemedActivity(), ComposeView {
         if (emoji in standardReactionEmojis) return
 
         val updated = (listOf(emoji) + recentEmojis().filter { it != emoji })
-            .take(Preferences.REACTION_RECENTS_MAX)
+            .take(Preferences.REACTION_RECENTS_STORE_MAX)
         prefs.reactionRecents.set(updated.joinToString("\n"))
     }
 

--- a/presentation/src/main/java/com/moez/QKSMS/feature/compose/ComposeActivity.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/feature/compose/ComposeActivity.kt
@@ -107,6 +107,7 @@ import java.util.Calendar
 import java.util.Date
 import java.util.Locale
 import java.util.concurrent.TimeUnit
+import kotlin.math.ceil
 import javax.inject.Inject
 
 
@@ -767,40 +768,65 @@ class ComposeActivity : QkThemedActivity(), ComposeView {
         // emojis look dim.
         val chipTextColor = resolveThemeColor(android.R.attr.textColorPrimary) or 0xFF000000.toInt()
 
-        reactionPickerEmojis().forEach { emoji ->
-            container.addView((layoutInflater.inflate(R.layout.reaction_bar_emoji, container, false) as TextView)
+        val chips = mutableListOf<TextView>()
+
+        val addChip = { label: String, onClick: () -> Unit ->
+            val chip = (layoutInflater.inflate(R.layout.reaction_bar_emoji, container, false) as TextView)
                 .apply {
-                    text = emoji
+                    text = label
                     setTextColor(chipTextColor)
-                    setOnClickListener {
-                        reactionSelectedIntent.onNext(messageId to emoji)
-                        rememberRecentEmoji(emoji)
-                        reactionPopup?.dismiss()
-                    }
-                })
+                    setOnClickListener { onClick() }
+                }
+            chips.add(chip)
+            container.addView(chip)
+        }
+
+        reactionPickerEmojis().forEach { emoji ->
+            addChip(emoji) {
+                reactionSelectedIntent.onNext(messageId to emoji)
+                rememberRecentEmoji(emoji)
+                reactionPopup?.dismiss()
+            }
         }
 
         // the '+' opens the full system emoji keyboard so any emoji can be used
-        container.addView((layoutInflater.inflate(R.layout.reaction_bar_emoji, container, false) as TextView)
-            .apply {
-                text = "+"
-                setTextColor(chipTextColor)
-                setOnClickListener {
-                    reactionPopup?.dismiss()
-                    promptForCustomEmoji(messageId)
-                }
-            })
+        addChip("+") {
+            reactionPopup?.dismiss()
+            promptForCustomEmoji(messageId)
+        }
 
         val margin = (resources.displayMetrics.density * 8).toInt()
         val screenWidth = resources.displayMetrics.widthPixels
         val available = screenWidth - (2 * margin)
 
-        // constrain to the available width so the flexbox wraps onto multiple lines when needed
+        // Give every chip a uniform width, then work out a balanced number of chips per row so a
+        // wrapped picker doesn't leave a near-empty last row (eg. 8 + 1). We spread the chips as
+        // evenly as possible across however many rows are needed at the available width.
+        var chipWidth = 0
+        chips.forEach { chip ->
+            chip.measure(
+                View.MeasureSpec.makeMeasureSpec(0, View.MeasureSpec.UNSPECIFIED),
+                View.MeasureSpec.makeMeasureSpec(0, View.MeasureSpec.UNSPECIFIED)
+            )
+            chipWidth = maxOf(chipWidth, chip.measuredWidth)
+        }
+        val paddingH = container.paddingLeft + container.paddingRight
+        val innerAvailable = (available - paddingH).coerceAtLeast(chipWidth)
+        val maxPerRow = (innerAvailable / chipWidth).coerceAtLeast(1)
+        val rowCount = ceil(chips.size.toDouble() / maxPerRow).toInt().coerceAtLeast(1)
+        val perRow = ceil(chips.size.toDouble() / rowCount).toInt().coerceAtLeast(1)
+
+        chips.forEach { chip ->
+            chip.layoutParams = FlexboxLayout.LayoutParams(chipWidth, FlexboxLayout.LayoutParams.WRAP_CONTENT)
+        }
+
+        // a couple of pixels of slack so rounding never bumps a chip onto the next row
+        val shownWidth = perRow * chipWidth + paddingH + 2
+
         container.measure(
-            View.MeasureSpec.makeMeasureSpec(available, View.MeasureSpec.AT_MOST),
+            View.MeasureSpec.makeMeasureSpec(shownWidth, View.MeasureSpec.EXACTLY),
             View.MeasureSpec.makeMeasureSpec(0, View.MeasureSpec.UNSPECIFIED)
         )
-        val shownWidth = container.measuredWidth
 
         val popup = PopupWindow(
             container,

--- a/presentation/src/main/java/com/moez/QKSMS/feature/compose/ComposeActivity.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/feature/compose/ComposeActivity.kt
@@ -762,10 +762,16 @@ class ComposeActivity : QkThemedActivity(), ComposeView {
         (container.background?.mutate() as? GradientDrawable)
             ?.setColor(resolveThemeColor(android.R.attr.windowBackground))
 
+        // Force a fully-opaque text colour: a TextView's text-colour alpha is applied to emoji
+        // glyphs too, and the theme's default text colour is partially transparent, which makes the
+        // emojis look dim.
+        val chipTextColor = resolveThemeColor(android.R.attr.textColorPrimary) or 0xFF000000.toInt()
+
         reactionPickerEmojis().forEach { emoji ->
             container.addView((layoutInflater.inflate(R.layout.reaction_bar_emoji, container, false) as TextView)
                 .apply {
                     text = emoji
+                    setTextColor(chipTextColor)
                     setOnClickListener {
                         reactionSelectedIntent.onNext(messageId to emoji)
                         rememberRecentEmoji(emoji)
@@ -778,6 +784,7 @@ class ComposeActivity : QkThemedActivity(), ComposeView {
         container.addView((layoutInflater.inflate(R.layout.reaction_bar_emoji, container, false) as TextView)
             .apply {
                 text = "+"
+                setTextColor(chipTextColor)
                 setOnClickListener {
                     reactionPopup?.dismiss()
                     promptForCustomEmoji(messageId)

--- a/presentation/src/main/java/com/moez/QKSMS/feature/compose/ComposeView.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/feature/compose/ComposeView.kt
@@ -78,6 +78,9 @@ interface ComposeView : QkView<ComposeState> {
     val clearCurrentMessageIntent: Subject<Boolean>
     val messageLinkAskIntent: Observable<Uri>
     val reactionClickIntent: Subject<Long>
+
+    // emitted when the user picks an emoji from the reaction picker (message id, emoji)
+    val reactionSelectedIntent: Subject<Pair<Long, String>>
     val speechRecogniserIntent: Observable<*>
     val shadeIntent: Observable<Unit>
     val recordAudioStartStopRecording: Subject<Boolean>

--- a/presentation/src/main/java/com/moez/QKSMS/feature/compose/ComposeViewModel.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/feature/compose/ComposeViewModel.kt
@@ -61,6 +61,7 @@ import dev.octoshrimpy.quik.interactor.MarkRead
 import dev.octoshrimpy.quik.interactor.SendExistingMessage
 import dev.octoshrimpy.quik.interactor.SaveImage
 import dev.octoshrimpy.quik.interactor.SendNewMessage
+import dev.octoshrimpy.quik.interactor.SendReaction
 import dev.octoshrimpy.quik.manager.ActiveConversationManager
 import dev.octoshrimpy.quik.manager.BillingManager
 import dev.octoshrimpy.quik.manager.PermissionManager
@@ -127,6 +128,7 @@ class ComposeViewModel @Inject constructor(
     private val prefs: Preferences,
     private val sendExistingMessage: SendExistingMessage,
     private val sendNewMessage: SendNewMessage,
+    private val sendReaction: SendReaction,
     private val subscriptionManager: SubscriptionManagerCompat,
     private val saveImage: SaveImage,
 ) : QkViewModel<ComposeView, ComposeState>(ComposeState(
@@ -766,17 +768,37 @@ class ComposeViewModel @Inject constructor(
             .mapNotNull { messageId -> messageRepo.getMessage(messageId) }
             .withLatestFrom(conversation) { message, conv ->
                 message.emojiReactions.map { reaction ->
-                    val contactName = conv.recipients
-                        .firstOrNull { recipient ->
-                            phoneNumberUtils.compare(recipient.address, reaction.senderAddress)
-                        }
-                        ?.getDisplayName()
-                        ?: reaction.senderAddress
+                    val contactName = when {
+                        reaction.fromMe -> context.getString(R.string.compose_reaction_you)
+                        else -> conv.recipients
+                            .firstOrNull { recipient ->
+                                phoneNumberUtils.compare(recipient.address, reaction.senderAddress)
+                            }
+                            ?.getDisplayName()
+                            ?: reaction.senderAddress
+                    }
                     "${reaction.emoji} $contactName"
                 }
             }
             .autoDisposable(view.scope())
             .subscribe { reactions -> view.showReactionsDialog(reactions) }
+
+        // Send (or toggle off) an emoji reaction chosen from the reaction picker
+        view.reactionSelectedIntent
+            .filter { permissionManager.isDefaultSms().also { if (!it) view.requestDefaultSms() } }
+            .withLatestFrom(state) { (messageId, emoji), state ->
+                Triple(state.subscription?.subscriptionId ?: -1, messageId, emoji)
+            }
+            .autoDisposable(view.scope())
+            .subscribe { (subId, messageId, emoji) ->
+                // reacting again with the same emoji removes it (toggle)
+                val isRemoval = messageRepo.getMessage(messageId)
+                    ?.emojiReactions
+                    ?.any { it.fromMe && it.emoji == emoji }
+                    ?: false
+
+                sendReaction.execute(SendReaction.Params(subId, messageId, emoji, isRemoval))
+            }
 
         // Set the current conversation
         Observables

--- a/presentation/src/main/java/com/moez/QKSMS/feature/compose/MessagesAdapter.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/feature/compose/MessagesAdapter.kt
@@ -23,6 +23,7 @@ import android.content.Context
 import android.graphics.Typeface
 import android.net.Uri
 import android.os.Build
+import android.os.SystemClock
 import android.text.Layout
 import android.text.Spannable
 import android.text.SpannableString
@@ -34,6 +35,7 @@ import android.text.style.URLSpan
 import android.text.util.Linkify
 import android.view.LayoutInflater
 import android.view.View
+import android.view.ViewConfiguration
 import android.view.ViewGroup
 import android.widget.ImageView
 import android.widget.ProgressBar
@@ -112,6 +114,10 @@ class MessagesAdapter @Inject constructor(
     val partContextMenuRegistrar: Subject<View> = PublishSubject.create()
     val reactionClicks: Subject<Long> = PublishSubject.create()
 
+    // emits (message id, anchor view) when the user asks to react to a message; the anchor view is
+    // used to position the floating reaction picker above the bubble
+    val reactionBarClicks: Subject<Pair<Long, View>> = PublishSubject.create()
+
     var data: Pair<Conversation, RealmResults<Message>>? = null
         set(value) {
             if (field === value) return
@@ -170,24 +176,73 @@ class MessagesAdapter @Inject constructor(
 
         return QkViewHolder(view).apply {
             view.setOnClickListener {
-                getItem(adapterPosition)?.let {
-                    when (toggleSelection(it.id, false)) {
-                        true -> view.isActivated = isSelected(it.id)
-                        false -> {
-                            expanded[it.id] = status.visibility != View.VISIBLE
-                            notifyItemChanged(adapterPosition)
-                        }
+                val id = getItem(adapterPosition)?.id ?: return@setOnClickListener
+
+                // In selection mode, or when double-tap isn't bound to an action, act immediately.
+                // Otherwise defer the single-tap so we can detect a double-tap.
+                if (isSelectionMode()) {
+                    onSingleTap(id, view, status)
+                } else {
+                    val now = SystemClock.uptimeMillis()
+                    if (id == lastClickId && (now - lastClickTime) < doubleTapTimeout) {
+                        lastClickTime = 0
+                        pendingSingleTap?.let { view.removeCallbacks(it) }
+                        onDoubleTap(id, view)
+                    } else {
+                        lastClickId = id
+                        lastClickTime = now
+                        val runnable = Runnable { onSingleTap(id, view, status) }
+                        pendingSingleTap = runnable
+                        view.postDelayed(runnable, doubleTapTimeout)
                     }
                 }
             }
             view.setOnLongClickListener {
-                getItem(adapterPosition)?.let {
-                    toggleSelection(it.id)
-                    view.isActivated = isSelected(it.id)
-                }
+                getItem(adapterPosition)?.let { onLongPress(it.id, view) }
                 true
             }
         }
+    }
+
+    private val doubleTapTimeout = ViewConfiguration.getDoubleTapTimeout().toLong()
+    private var lastClickTime = 0L
+    private var lastClickId = -1L
+    private var pendingSingleTap: Runnable? = null
+
+    /** Whether the react gesture is long-press (vs double-tap); the other gesture multi-selects */
+    private val reactOnLongPress: Boolean
+        get() = prefs.reactionGesture.get() == Preferences.REACTION_GESTURE_LONG_PRESS
+
+    private fun onSingleTap(id: Long, view: View, status: View) {
+        when (toggleSelection(id, false)) {
+            true -> view.isActivated = isSelected(id)
+            false -> {
+                expanded[id] = status.visibility != View.VISIBLE
+                val position = getItemPositionForId(id)
+                if (position != androidx.recyclerview.widget.RecyclerView.NO_POSITION)
+                    notifyItemChanged(position)
+            }
+        }
+    }
+
+    private fun onLongPress(id: Long, view: View) {
+        if (reactOnLongPress) reactionBarClicks.onNext(id to view)
+        else enterSelection(id, view)
+    }
+
+    private fun onDoubleTap(id: Long, view: View) {
+        if (reactOnLongPress) enterSelection(id, view)
+        else reactionBarClicks.onNext(id to view)
+    }
+
+    private fun enterSelection(id: Long, view: View) {
+        toggleSelection(id)
+        view.isActivated = isSelected(id)
+    }
+
+    private fun getItemPositionForId(id: Long): Int {
+        for (i in 0 until itemCount) if (getItem(i)?.id == id) return i
+        return androidx.recyclerview.widget.RecyclerView.NO_POSITION
     }
 
     override fun onBindViewHolder(holder: QkViewHolder, position: Int) {

--- a/presentation/src/main/java/com/moez/QKSMS/feature/compose/MessagesAdapter.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/feature/compose/MessagesAdapter.kt
@@ -487,15 +487,14 @@ class MessagesAdapter @Inject constructor(
         val hasReactions = reactions.isNotEmpty()
 
         if (hasReactions) {
-            val uniqueEmojis = reactions.map { it.emoji }.distinct()
-            val totalCount = reactions.size
-
-            // Show unique emojis followed by total count
-            val reactionText = if (totalCount == 1) {
-                uniqueEmojis.first()
-            } else {
-                "${uniqueEmojis.joinToString("")}\u00A0$totalCount"
-            }
+            // Show each distinct emoji (in first-seen order), with a count after it only when that
+            // same emoji was used more than once, eg. "\uD83D\uDC4D\u2764\uFE0F2\uD83D\uDE02"
+            val reactionText = reactions
+                .groupBy { it.emoji }
+                .entries
+                .joinToString(separator = "\u2002") { (emoji, list) ->
+                    if (list.size > 1) "$emoji${list.size}" else emoji
+                }
 
             reactionTextView.text = reactionText
             reactionTextView.setOnClickListener { reactionClicks.onNext(message.id) }

--- a/presentation/src/main/java/com/moez/QKSMS/feature/extensions/CharSequenceExtensions.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/feature/extensions/CharSequenceExtensions.kt
@@ -14,7 +14,18 @@ fun CharSequence.isEmojiOnly(considerWhitespace: Boolean = false): Boolean {
     if (cs.isEmpty())
         return false
 
-    return when (val spannable = EmojiCompat.get().process(
+    // EmojiCompat loads its font asynchronously; calling process() before it has finished loading
+    // throws "Not initialized yet". Until it's ready, treat the text as not emoji-only (it'll be
+    // re-evaluated once the view rebinds after loading completes).
+    val emojiCompat = try {
+        EmojiCompat.get()
+    } catch (e: IllegalStateException) {
+        return false
+    }
+    if (emojiCompat.loadState != EmojiCompat.LOAD_STATE_SUCCEEDED)
+        return false
+
+    return when (val spannable = emojiCompat.process(
         cs,
         0,
         (cs.length - 1),

--- a/presentation/src/main/java/com/moez/QKSMS/feature/settings/SettingsController.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/feature/settings/SettingsController.kt
@@ -71,6 +71,7 @@ class SettingsController : QkController<SettingsControllerBinding, SettingsView,
     @Inject lateinit var messageLinkHandlingDialog: QkDialog
     @Inject lateinit var reactionGestureDialog: QkDialog
     @Inject lateinit var reactionFormatDialog: QkDialog
+    @Inject lateinit var reactionRecentsDialog: QkDialog
 
     @Inject override lateinit var presenter: SettingsPresenter
 
@@ -109,6 +110,7 @@ class SettingsController : QkController<SettingsControllerBinding, SettingsView,
         messageLinkHandlingDialog.adapter.setData(R.array.messageLinkHandlings, R.array.messageLinkHandling_ids)
         reactionGestureDialog.adapter.setData(R.array.reaction_gestures, R.array.reaction_gesture_ids)
         reactionFormatDialog.adapter.setData(R.array.reaction_send_formats, R.array.reaction_send_format_ids)
+        reactionRecentsDialog.adapter.setData(R.array.reaction_recents_counts, R.array.reaction_recents_count_ids)
 
         binding.about.summary = context.getString(R.string.settings_version, BuildConfig.VERSION_NAME)
     }
@@ -147,6 +149,7 @@ class SettingsController : QkController<SettingsControllerBinding, SettingsView,
     override fun messageLinkHandlingSelected(): Observable<Int> = messageLinkHandlingDialog.adapter.menuItemClicks
     override fun reactionGestureSelected(): Observable<Int> = reactionGestureDialog.adapter.menuItemClicks
     override fun reactionFormatSelected(): Observable<Int> = reactionFormatDialog.adapter.menuItemClicks
+    override fun reactionRecentsSelected(): Observable<Int> = reactionRecentsDialog.adapter.menuItemClicks
 
     override fun render(state: SettingsState) {
         binding.theme.findViewById<View>(R.id.themePreview)?.setBackgroundTint(state.theme)
@@ -197,6 +200,9 @@ class SettingsController : QkController<SettingsControllerBinding, SettingsView,
 
         binding.reactionFormat.summary = state.reactionFormatSummary
         reactionFormatDialog.adapter.selectedItem = state.reactionFormatId
+
+        binding.reactionRecents.summary = state.reactionRecentsSummary
+        reactionRecentsDialog.adapter.selectedItem = state.reactionRecentsId
 
         binding.disableScreenshots.checkbox?.isChecked = state.disableScreenshotsEnabled
 
@@ -255,6 +261,7 @@ class SettingsController : QkController<SettingsControllerBinding, SettingsView,
     override fun showMessageLinkHandlingDialogPicker() = messageLinkHandlingDialog.show(activity!!)
     override fun showReactionGestureDialogPicker() = reactionGestureDialog.show(activity!!)
     override fun showReactionFormatDialogPicker() = reactionFormatDialog.show(activity!!)
+    override fun showReactionRecentsDialogPicker() = reactionRecentsDialog.show(activity!!)
 
     override fun showSwipeActions() {
         router.pushController(RouterTransaction.with(SwipeActionsController())

--- a/presentation/src/main/java/com/moez/QKSMS/feature/settings/SettingsController.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/feature/settings/SettingsController.kt
@@ -69,6 +69,8 @@ class SettingsController : QkController<SettingsControllerBinding, SettingsView,
     @Inject lateinit var sendDelayDialog: QkDialog
     @Inject lateinit var mmsSizeDialog: QkDialog
     @Inject lateinit var messageLinkHandlingDialog: QkDialog
+    @Inject lateinit var reactionGestureDialog: QkDialog
+    @Inject lateinit var reactionFormatDialog: QkDialog
 
     @Inject override lateinit var presenter: SettingsPresenter
 
@@ -105,6 +107,8 @@ class SettingsController : QkController<SettingsControllerBinding, SettingsView,
         sendDelayDialog.adapter.setData(R.array.delayed_sending_labels)
         mmsSizeDialog.adapter.setData(R.array.mms_sizes, R.array.mms_sizes_ids)
         messageLinkHandlingDialog.adapter.setData(R.array.messageLinkHandlings, R.array.messageLinkHandling_ids)
+        reactionGestureDialog.adapter.setData(R.array.reaction_gestures, R.array.reaction_gesture_ids)
+        reactionFormatDialog.adapter.setData(R.array.reaction_send_formats, R.array.reaction_send_format_ids)
 
         binding.about.summary = context.getString(R.string.settings_version, BuildConfig.VERSION_NAME)
     }
@@ -141,6 +145,8 @@ class SettingsController : QkController<SettingsControllerBinding, SettingsView,
     override fun mmsSizeSelected(): Observable<Int> = mmsSizeDialog.adapter.menuItemClicks
 
     override fun messageLinkHandlingSelected(): Observable<Int> = messageLinkHandlingDialog.adapter.menuItemClicks
+    override fun reactionGestureSelected(): Observable<Int> = reactionGestureDialog.adapter.menuItemClicks
+    override fun reactionFormatSelected(): Observable<Int> = reactionFormatDialog.adapter.menuItemClicks
 
     override fun render(state: SettingsState) {
         binding.theme.findViewById<View>(R.id.themePreview)?.setBackgroundTint(state.theme)
@@ -185,6 +191,12 @@ class SettingsController : QkController<SettingsControllerBinding, SettingsView,
 
         binding.messsageLinkHandling.summary = state.messageLinkHandlingSummary
         messageLinkHandlingDialog.adapter.selectedItem = state.messageLinkHandlingId
+
+        binding.reactionGesture.summary = state.reactionGestureSummary
+        reactionGestureDialog.adapter.selectedItem = state.reactionGestureId
+
+        binding.reactionFormat.summary = state.reactionFormatSummary
+        reactionFormatDialog.adapter.selectedItem = state.reactionFormatId
 
         binding.disableScreenshots.checkbox?.isChecked = state.disableScreenshotsEnabled
 
@@ -241,6 +253,8 @@ class SettingsController : QkController<SettingsControllerBinding, SettingsView,
     override fun showMmsSizePicker() = mmsSizeDialog.show(activity!!)
 
     override fun showMessageLinkHandlingDialogPicker() = messageLinkHandlingDialog.show(activity!!)
+    override fun showReactionGestureDialogPicker() = reactionGestureDialog.show(activity!!)
+    override fun showReactionFormatDialogPicker() = reactionFormatDialog.show(activity!!)
 
     override fun showSwipeActions() {
         router.pushController(RouterTransaction.with(SwipeActionsController())

--- a/presentation/src/main/java/com/moez/QKSMS/feature/settings/SettingsPresenter.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/feature/settings/SettingsPresenter.kt
@@ -168,6 +168,19 @@ class SettingsPresenter @Inject constructor(
                 }
             }
 
+        val reactionRecentsLabels = context.resources.getStringArray(R.array.reaction_recents_counts)
+        val reactionRecentsIds = context.resources.getIntArray(R.array.reaction_recents_count_ids)
+        disposables += prefs.reactionRecentsCount.asObservable()
+            .subscribe { reactionRecentsId ->
+                val index = reactionRecentsIds.indexOf(reactionRecentsId).coerceAtLeast(0)
+                newState {
+                    copy(
+                        reactionRecentsSummary = reactionRecentsLabels[index],
+                        reactionRecentsId = reactionRecentsId
+                    )
+                }
+            }
+
         disposables += prefs.disableScreenshots.asObservable()
             .subscribe { enabled -> newState { copy(disableScreenshotsEnabled = enabled) } }
 
@@ -246,6 +259,8 @@ class SettingsPresenter @Inject constructor(
 
                         R.id.reactionFormat -> view.showReactionFormatDialogPicker()
 
+                        R.id.reactionRecents -> view.showReactionRecentsDialogPicker()
+
                         R.id.disableScreenshots -> prefs.disableScreenshots.set(!prefs.disableScreenshots.get())
 
                         R.id.sync -> syncMessages.execute(Unit)
@@ -323,6 +338,10 @@ class SettingsPresenter @Inject constructor(
         view.reactionFormatSelected()
             .autoDisposable(view.scope())
             .subscribe(prefs.reactionSendFormat::set)
+
+        view.reactionRecentsSelected()
+            .autoDisposable(view.scope())
+            .subscribe(prefs.reactionRecentsCount::set)
     }
 
 }

--- a/presentation/src/main/java/com/moez/QKSMS/feature/settings/SettingsPresenter.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/feature/settings/SettingsPresenter.kt
@@ -142,6 +142,32 @@ class SettingsPresenter @Inject constructor(
                     )
                 }
             }
+        val reactionGestureLabels = context.resources.getStringArray(R.array.reaction_gestures)
+        val reactionGestureIds = context.resources.getIntArray(R.array.reaction_gesture_ids)
+        disposables += prefs.reactionGesture.asObservable()
+            .subscribe { reactionGestureId ->
+                val index = reactionGestureIds.indexOf(reactionGestureId).coerceAtLeast(0)
+                newState {
+                    copy(
+                        reactionGestureSummary = reactionGestureLabels[index],
+                        reactionGestureId = reactionGestureId
+                    )
+                }
+            }
+
+        val reactionFormatLabels = context.resources.getStringArray(R.array.reaction_send_formats)
+        val reactionFormatIds = context.resources.getIntArray(R.array.reaction_send_format_ids)
+        disposables += prefs.reactionSendFormat.asObservable()
+            .subscribe { reactionFormatId ->
+                val index = reactionFormatIds.indexOf(reactionFormatId).coerceAtLeast(0)
+                newState {
+                    copy(
+                        reactionFormatSummary = reactionFormatLabels[index],
+                        reactionFormatId = reactionFormatId
+                    )
+                }
+            }
+
         disposables += prefs.disableScreenshots.asObservable()
             .subscribe { enabled -> newState { copy(disableScreenshotsEnabled = enabled) } }
 
@@ -216,6 +242,10 @@ class SettingsPresenter @Inject constructor(
 
                         R.id.messsageLinkHandling -> view.showMessageLinkHandlingDialogPicker()
 
+                        R.id.reactionGesture -> view.showReactionGestureDialogPicker()
+
+                        R.id.reactionFormat -> view.showReactionFormatDialogPicker()
+
                         R.id.disableScreenshots -> prefs.disableScreenshots.set(!prefs.disableScreenshots.get())
 
                         R.id.sync -> syncMessages.execute(Unit)
@@ -285,6 +315,14 @@ class SettingsPresenter @Inject constructor(
         view.messageLinkHandlingSelected()
             .autoDisposable(view.scope())
             .subscribe(prefs.messageLinkHandling::set)
+
+        view.reactionGestureSelected()
+            .autoDisposable(view.scope())
+            .subscribe(prefs.reactionGesture::set)
+
+        view.reactionFormatSelected()
+            .autoDisposable(view.scope())
+            .subscribe(prefs.reactionSendFormat::set)
     }
 
 }

--- a/presentation/src/main/java/com/moez/QKSMS/feature/settings/SettingsState.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/feature/settings/SettingsState.kt
@@ -50,7 +50,7 @@ data class SettingsState(
     val maxMmsSizeId: Int = 100,
     val messageLinkHandlingSummary: String = "Ask before opening",
     val messageLinkHandlingId: Int = 2,
-    val reactionGestureSummary: String = "Long press to react",
+    val reactionGestureSummary: String = "Long-press to react, double-tap to select",
     val reactionGestureId: Int = 0,
     val reactionFormatSummary: String = "Automatic",
     val reactionFormatId: Int = 0,

--- a/presentation/src/main/java/com/moez/QKSMS/feature/settings/SettingsState.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/feature/settings/SettingsState.kt
@@ -54,6 +54,8 @@ data class SettingsState(
     val reactionGestureId: Int = 0,
     val reactionFormatSummary: String = "Automatic",
     val reactionFormatId: Int = 0,
+    val reactionRecentsSummary: String = "3",
+    val reactionRecentsId: Int = 3,
     val disableScreenshotsEnabled: Boolean = false,
     val syncProgress: SyncRepository.SyncProgress = SyncRepository.SyncProgress.Idle
 )

--- a/presentation/src/main/java/com/moez/QKSMS/feature/settings/SettingsState.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/feature/settings/SettingsState.kt
@@ -50,6 +50,10 @@ data class SettingsState(
     val maxMmsSizeId: Int = 100,
     val messageLinkHandlingSummary: String = "Ask before opening",
     val messageLinkHandlingId: Int = 2,
+    val reactionGestureSummary: String = "Long press to react",
+    val reactionGestureId: Int = 0,
+    val reactionFormatSummary: String = "Automatic",
+    val reactionFormatId: Int = 0,
     val disableScreenshotsEnabled: Boolean = false,
     val syncProgress: SyncRepository.SyncProgress = SyncRepository.SyncProgress.Idle
 )

--- a/presentation/src/main/java/com/moez/QKSMS/feature/settings/SettingsView.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/feature/settings/SettingsView.kt
@@ -34,6 +34,8 @@ interface SettingsView : QkViewContract<SettingsState> {
     fun signatureChanged(): Observable<String>
     fun mmsSizeSelected(): Observable<Int>
     fun messageLinkHandlingSelected(): Observable<Int>
+    fun reactionGestureSelected(): Observable<Int>
+    fun reactionFormatSelected(): Observable<Int>
 
     fun showQksmsPlusSnackbar()
     fun showNightModeDialog()
@@ -44,6 +46,8 @@ interface SettingsView : QkViewContract<SettingsState> {
     fun showSignatureDialog(signature: String)
     fun showMmsSizePicker()
     fun showMessageLinkHandlingDialogPicker()
+    fun showReactionGestureDialogPicker()
+    fun showReactionFormatDialogPicker()
     fun showSwipeActions()
     fun showThemePicker()
     fun showAbout()

--- a/presentation/src/main/java/com/moez/QKSMS/feature/settings/SettingsView.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/feature/settings/SettingsView.kt
@@ -36,6 +36,7 @@ interface SettingsView : QkViewContract<SettingsState> {
     fun messageLinkHandlingSelected(): Observable<Int>
     fun reactionGestureSelected(): Observable<Int>
     fun reactionFormatSelected(): Observable<Int>
+    fun reactionRecentsSelected(): Observable<Int>
 
     fun showQksmsPlusSnackbar()
     fun showNightModeDialog()
@@ -48,6 +49,7 @@ interface SettingsView : QkViewContract<SettingsState> {
     fun showMessageLinkHandlingDialogPicker()
     fun showReactionGestureDialogPicker()
     fun showReactionFormatDialogPicker()
+    fun showReactionRecentsDialogPicker()
     fun showSwipeActions()
     fun showThemePicker()
     fun showAbout()

--- a/presentation/src/main/res/drawable/reaction_bar_background.xml
+++ b/presentation/src/main/res/drawable/reaction_bar_background.xml
@@ -17,26 +17,12 @@
   ~ You should have received a copy of the GNU General Public License
   ~ along with QUIK.  If not, see <http://www.gnu.org/licenses/>.
   -->
-<menu xmlns:android="http://schemas.android.com/apk/res/android">
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
 
-    <item
-        android:id="@+id/reactToPart"
-        android:title="@string/compose_menu_react" />
+    <!-- solid colour is overridden at runtime to match the current theme -->
+    <solid android:color="@color/white" />
 
-    <item
-        android:id="@+id/save"
-        android:title="@string/menu_mms_part_save" />
+    <corners android:radius="24dp" />
 
-    <item
-        android:id="@+id/share"
-        android:title="@string/menu_mms_part_share" />
-
-    <item
-        android:id="@+id/forward"
-        android:title="@string/menu_mms_part_forward" />
-
-    <item
-        android:id="@+id/openExternally"
-        android:title="@string/menu_mms_part_open" />
-
-</menu>
+</shape>

--- a/presentation/src/main/res/layout/reaction_bar.xml
+++ b/presentation/src/main/res/layout/reaction_bar.xml
@@ -17,50 +17,16 @@
   ~ You should have received a copy of the GNU General Public License
   ~ along with QUIK.  If not, see <http://www.gnu.org/licenses/>.
   -->
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    android:id="@+id/reactionBarRoot"
+<com.google.android.flexbox.FlexboxLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/reactionBarContainer"
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
-    android:orientation="horizontal"
     android:background="@drawable/reaction_bar_background"
     android:elevation="8dp"
-    android:gravity="center_vertical"
     android:paddingStart="4dp"
     android:paddingEnd="4dp"
     android:paddingTop="2dp"
-    android:paddingBottom="2dp">
-
-    <!-- scrollable list of default + recent emojis -->
-    <HorizontalScrollView
-        android:id="@+id/reactionScroll"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:overScrollMode="never"
-        android:scrollbars="none">
-
-        <LinearLayout
-            android:id="@+id/reactionBarContainer"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:gravity="center_vertical"
-            android:orientation="horizontal" />
-
-    </HorizontalScrollView>
-
-    <!-- the '+' stays pinned so it is always reachable, even when the list overflows -->
-    <TextView
-        android:id="@+id/reactionPlus"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:background="?attr/selectableItemBackgroundBorderless"
-        android:clickable="true"
-        android:focusable="true"
-        android:gravity="center"
-        android:minWidth="44dp"
-        android:minHeight="44dp"
-        android:paddingStart="6dp"
-        android:paddingEnd="6dp"
-        android:text="+"
-        android:textSize="24sp" />
-
-</LinearLayout>
+    android:paddingBottom="2dp"
+    app:alignItems="center"
+    app:flexWrap="wrap" />

--- a/presentation/src/main/res/layout/reaction_bar.xml
+++ b/presentation/src/main/res/layout/reaction_bar.xml
@@ -18,7 +18,7 @@
   ~ along with QUIK.  If not, see <http://www.gnu.org/licenses/>.
   -->
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    android:id="@+id/reactionBarContainer"
+    android:id="@+id/reactionBarRoot"
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
     android:orientation="horizontal"
@@ -28,4 +28,39 @@
     android:paddingStart="4dp"
     android:paddingEnd="4dp"
     android:paddingTop="2dp"
-    android:paddingBottom="2dp" />
+    android:paddingBottom="2dp">
+
+    <!-- scrollable list of default + recent emojis -->
+    <HorizontalScrollView
+        android:id="@+id/reactionScroll"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:overScrollMode="never"
+        android:scrollbars="none">
+
+        <LinearLayout
+            android:id="@+id/reactionBarContainer"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:gravity="center_vertical"
+            android:orientation="horizontal" />
+
+    </HorizontalScrollView>
+
+    <!-- the '+' stays pinned so it is always reachable, even when the list overflows -->
+    <TextView
+        android:id="@+id/reactionPlus"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:background="?attr/selectableItemBackgroundBorderless"
+        android:clickable="true"
+        android:focusable="true"
+        android:gravity="center"
+        android:minWidth="44dp"
+        android:minHeight="44dp"
+        android:paddingStart="6dp"
+        android:paddingEnd="6dp"
+        android:text="+"
+        android:textSize="24sp" />
+
+</LinearLayout>

--- a/presentation/src/main/res/layout/reaction_bar.xml
+++ b/presentation/src/main/res/layout/reaction_bar.xml
@@ -29,4 +29,5 @@
     android:paddingTop="2dp"
     android:paddingBottom="2dp"
     app:alignItems="center"
-    app:flexWrap="wrap" />
+    app:flexWrap="wrap"
+    app:justifyContent="center" />

--- a/presentation/src/main/res/layout/reaction_bar.xml
+++ b/presentation/src/main/res/layout/reaction_bar.xml
@@ -17,26 +17,15 @@
   ~ You should have received a copy of the GNU General Public License
   ~ along with QUIK.  If not, see <http://www.gnu.org/licenses/>.
   -->
-<menu xmlns:android="http://schemas.android.com/apk/res/android">
-
-    <item
-        android:id="@+id/reactToPart"
-        android:title="@string/compose_menu_react" />
-
-    <item
-        android:id="@+id/save"
-        android:title="@string/menu_mms_part_save" />
-
-    <item
-        android:id="@+id/share"
-        android:title="@string/menu_mms_part_share" />
-
-    <item
-        android:id="@+id/forward"
-        android:title="@string/menu_mms_part_forward" />
-
-    <item
-        android:id="@+id/openExternally"
-        android:title="@string/menu_mms_part_open" />
-
-</menu>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/reactionBarContainer"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    android:orientation="horizontal"
+    android:background="@drawable/reaction_bar_background"
+    android:elevation="8dp"
+    android:gravity="center_vertical"
+    android:paddingStart="4dp"
+    android:paddingEnd="4dp"
+    android:paddingTop="2dp"
+    android:paddingBottom="2dp" />

--- a/presentation/src/main/res/layout/reaction_bar_emoji.xml
+++ b/presentation/src/main/res/layout/reaction_bar_emoji.xml
@@ -17,26 +17,15 @@
   ~ You should have received a copy of the GNU General Public License
   ~ along with QUIK.  If not, see <http://www.gnu.org/licenses/>.
   -->
-<menu xmlns:android="http://schemas.android.com/apk/res/android">
-
-    <item
-        android:id="@+id/reactToPart"
-        android:title="@string/compose_menu_react" />
-
-    <item
-        android:id="@+id/save"
-        android:title="@string/menu_mms_part_save" />
-
-    <item
-        android:id="@+id/share"
-        android:title="@string/menu_mms_part_share" />
-
-    <item
-        android:id="@+id/forward"
-        android:title="@string/menu_mms_part_forward" />
-
-    <item
-        android:id="@+id/openExternally"
-        android:title="@string/menu_mms_part_open" />
-
-</menu>
+<TextView xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    android:background="?attr/selectableItemBackgroundBorderless"
+    android:clickable="true"
+    android:focusable="true"
+    android:gravity="center"
+    android:minWidth="44dp"
+    android:minHeight="44dp"
+    android:paddingStart="6dp"
+    android:paddingEnd="6dp"
+    android:textSize="24sp" />

--- a/presentation/src/main/res/layout/settings_controller.xml
+++ b/presentation/src/main/res/layout/settings_controller.xml
@@ -138,6 +138,7 @@
             android:id="@+id/reactionGesture"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
+            app:icon="@drawable/ic_favorite_black_24dp"
             app:title="@string/settings_reaction_gesture_title"
             tools:summary="Long press to react" />
 
@@ -145,6 +146,7 @@
             android:id="@+id/reactionFormat"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
+            app:icon="@drawable/ic_send_black_24dp"
             app:title="@string/settings_reaction_format_title"
             tools:summary="Automatic" />
 
@@ -152,6 +154,7 @@
             android:id="@+id/reactionRecents"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
+            app:icon="@drawable/ic_history_black_24dp"
             app:title="@string/settings_reaction_recents_title"
             tools:summary="3" />
 

--- a/presentation/src/main/res/layout/settings_controller.xml
+++ b/presentation/src/main/res/layout/settings_controller.xml
@@ -149,6 +149,13 @@
             tools:summary="Automatic" />
 
         <dev.octoshrimpy.quik.common.widget.PreferenceView
+            android:id="@+id/reactionRecents"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            app:title="@string/settings_reaction_recents_title"
+            tools:summary="3" />
+
+        <dev.octoshrimpy.quik.common.widget.PreferenceView
             android:id="@+id/delayed"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"

--- a/presentation/src/main/res/layout/settings_controller.xml
+++ b/presentation/src/main/res/layout/settings_controller.xml
@@ -135,6 +135,20 @@
             app:widget="@layout/settings_switch_widget" />
 
         <dev.octoshrimpy.quik.common.widget.PreferenceView
+            android:id="@+id/reactionGesture"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            app:title="@string/settings_reaction_gesture_title"
+            tools:summary="Long press to react" />
+
+        <dev.octoshrimpy.quik.common.widget.PreferenceView
+            android:id="@+id/reactionFormat"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            app:title="@string/settings_reaction_format_title"
+            tools:summary="Automatic" />
+
+        <dev.octoshrimpy.quik.common.widget.PreferenceView
             android:id="@+id/delayed"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"

--- a/presentation/src/main/res/values/strings.xml
+++ b/presentation/src/main/res/values/strings.xml
@@ -156,8 +156,6 @@
     <string name="compose_details_title">Message details</string>
     <string name="compose_reactions_title">Reactions</string>
     <string name="compose_menu_react">React</string>
-    <string name="compose_reaction_custom_title">Add a reaction</string>
-    <string name="compose_reaction_emoji_hint">Enter an emoji</string>
     <string name="compose_reaction_you">You</string>
     <string name="compose_details_type">Type: %s</string>
     <string name="compose_details_from">From: %s</string>

--- a/presentation/src/main/res/values/strings.xml
+++ b/presentation/src/main/res/values/strings.xml
@@ -277,7 +277,7 @@
     <string name="settings_system_font_title">Use system font</string>
     <string name="settings_system_show_stt_title">Show the speech-to-text button</string>
     <string name="settings_auto_emoji_title">Automatic emoji</string>
-    <string name="settings_reaction_gesture_title">Reaction gesture</string>
+    <string name="settings_reaction_gesture_title">Message gestures</string>
     <string name="settings_reaction_format_title">Reaction send format</string>
     <string name="settings_reaction_recents_title">Recent emojis in picker</string>
     <string name="settings_notifications_title">Notifications</string>
@@ -592,8 +592,8 @@
     </integer-array>
 
     <string-array name="reaction_gestures">
-        <item>Long press to react</item>
-        <item>Double tap to react</item>
+        <item>Long-press to react, double-tap to select</item>
+        <item>Double-tap to react, long-press to select</item>
     </string-array>
 
     <integer-array name="reaction_gesture_ids">

--- a/presentation/src/main/res/values/strings.xml
+++ b/presentation/src/main/res/values/strings.xml
@@ -279,6 +279,7 @@
     <string name="settings_auto_emoji_title">Automatic emoji</string>
     <string name="settings_reaction_gesture_title">Reaction gesture</string>
     <string name="settings_reaction_format_title">Reaction send format</string>
+    <string name="settings_reaction_recents_title">Recent emojis in picker</string>
     <string name="settings_notifications_title">Notifications</string>
     <string name="settings_notifications_o_summary">Tap to customize</string>
     <string name="settings_notification_actions_title">Actions</string>
@@ -610,6 +611,24 @@
         <item>0</item>
         <item>1</item>
         <item>2</item>
+    </integer-array>
+
+    <string-array name="reaction_recents_counts">
+        <item>None</item>
+        <item>1</item>
+        <item>2</item>
+        <item>3</item>
+        <item>4</item>
+        <item>5</item>
+    </string-array>
+
+    <integer-array name="reaction_recents_count_ids">
+        <item>0</item>
+        <item>1</item>
+        <item>2</item>
+        <item>3</item>
+        <item>4</item>
+        <item>5</item>
     </integer-array>
 
     <string-array name="qk_responses">

--- a/presentation/src/main/res/values/strings.xml
+++ b/presentation/src/main/res/values/strings.xml
@@ -155,6 +155,10 @@
     <string name="compose_menu_clear">Clear</string>
     <string name="compose_details_title">Message details</string>
     <string name="compose_reactions_title">Reactions</string>
+    <string name="compose_menu_react">React</string>
+    <string name="compose_reaction_custom_title">Add a reaction</string>
+    <string name="compose_reaction_emoji_hint">Enter an emoji</string>
+    <string name="compose_reaction_you">You</string>
     <string name="compose_details_type">Type: %s</string>
     <string name="compose_details_from">From: %s</string>
     <string name="compose_details_to">To: %s</string>
@@ -273,6 +277,8 @@
     <string name="settings_system_font_title">Use system font</string>
     <string name="settings_system_show_stt_title">Show the speech-to-text button</string>
     <string name="settings_auto_emoji_title">Automatic emoji</string>
+    <string name="settings_reaction_gesture_title">Reaction gesture</string>
+    <string name="settings_reaction_format_title">Reaction send format</string>
     <string name="settings_notifications_title">Notifications</string>
     <string name="settings_notifications_o_summary">Tap to customize</string>
     <string name="settings_notification_actions_title">Actions</string>
@@ -579,6 +585,28 @@
     </string-array>
 
     <integer-array name="messageLinkHandling_ids">
+        <item>0</item>
+        <item>1</item>
+        <item>2</item>
+    </integer-array>
+
+    <string-array name="reaction_gestures">
+        <item>Long press to react</item>
+        <item>Double tap to react</item>
+    </string-array>
+
+    <integer-array name="reaction_gesture_ids">
+        <item>0</item>
+        <item>1</item>
+    </integer-array>
+
+    <string-array name="reaction_send_formats">
+        <item>Automatic</item>
+        <item>Google Messages</item>
+        <item>iOS (readable text)</item>
+    </string-array>
+
+    <integer-array name="reaction_send_format_ids">
         <item>0</item>
         <item>1</item>
         <item>2</item>

--- a/presentation/src/main/res/values/themes.xml
+++ b/presentation/src/main/res/values/themes.xml
@@ -84,4 +84,23 @@
     <style name="AppThemeDialog.Black" />
     <style name="PopupTheme.Black" />
 
+    <!--
+      Material3 (floating) dialog theme used only for the emoji reaction picker. EmojiPickerView
+      reads Material3 colour attributes, which the app's AppCompat themes don't provide. DayNight
+      follows the app's night-mode setting via the -night resource qualifier. A floating dialog
+      theme lets us pin the window to a fixed height so the emoji grid gets a bounded, scrollable
+      viewport.
+    -->
+    <style name="ReactionEmojiPickerTheme" parent="Theme.Material3.DayNight">
+        <!-- Full-screen translucent window: the emoji drawer is pinned to the bottom over a dim
+             scrim we draw ourselves, so a swipe that starts above the drawer and travels into it
+             still dismisses (the whole gesture stays in one view hierarchy). The base DayNight
+             theme keeps EmojiPickerView following the app's night mode. -->
+        <item name="android:windowIsTranslucent">true</item>
+        <item name="android:windowBackground">@android:color/transparent</item>
+        <item name="android:backgroundDimEnabled">false</item>
+        <item name="android:windowNoTitle">true</item>
+        <item name="android:windowCloseOnTouchOutside">true</item>
+    </style>
+
 </resources>


### PR DESCRIPTION
## Send emoji reactions

QUIK could already **parse and display** incoming reactions (iMessage tapbacks and Google Messages reactions). This PR adds the missing half: **sending** reactions from within QUIK, so you can react to a message instead of only seeing reactions others send.

Closes #838
Closes #152

## Not just parity — QUIK goes further

This brings QUIK to parity with iMessage and Google Messages for reacting, and adds a couple of things they don't offer over SMS/MMS:

- **Cross-app reaction interoperability with per-conversation auto-detection.** QUIK can send in either the Google Messages (zero-width) format or human-readable iOS tapback text, and an **Automatic** mode mirrors whatever format was last received in that thread. So Android↔Android (Google Messages / QUIK) renders as a native reaction, while iPhone recipients get clean readable text (e.g. `Loved "…"`) instead of the Google format's stray invisible characters. No other SMS app we're aware of lets you choose or auto-match the reaction wire format.
- **Configurable react/select gesture.** Choose whether **long-press reacts and double-tap multi-selects, or vice-versa** — gesture customisation for reactions that iMessage and Google Messages don't offer.
- **Configurable recent-emoji count.** Show 0–5 of your most recently used emojis in the picker, right after the standard tapbacks.

## Full feature list

- Floating reaction picker anchored above the bubble (iMessage / Google-style), on long-press by default.
- Standard tapback quick row (❤️ 👍 👎 😂 ‼️ ❓), followed by your recent emojis, plus a **＋** that opens a full emoji grid picker (categorised, scrollable, tracks its own recents) for any emoji.
- React to text, image, and audio messages — media via the message's context menu, not just text.
- Add or remove a reaction by tapping — tapping the same emoji again removes it.
- Your reaction is recorded locally and shown instantly, and sent over SMS/MMS so the recipient's app can render it.
- Reaction badge shows a **per-emoji count** (e.g. `❤️2 👍`) rather than one combined total.
- The quick-reaction picker **wraps onto balanced rows** when it gets wide, instead of leaving a near-empty last row.
- New **Settings → Reactions**: *Message gestures*, *Reaction send format* (Automatic / Google Messages / iOS-readable), and *Recent emojis in picker*, each with an icon matching the existing rows.

## Implementation notes

- Reactions are sent as a normal (hidden) SMS/MMS message in the chosen wire format, reusing the existing send pipeline (delivery, retry, delay all apply). The reaction message is marked hidden the moment it's written to Realm, so the raw 'Reacted …' bubble never flashes in the conversation.
- Adds `fromMe` and `format` fields to the `EmojiReaction` model (Realm schema bump to v16, with migration).
- New `SendReaction` interactor and a `MessageRepository.sendReaction(...)` entry point; `EmojiReactionRepository` gains `buildReactionBody(...)` and `resolveFormat(...)`.
- iOS-readable outgoing templates are English for now (incoming parsing remains fully localised); other locales fall back to English.
- The full emoji grid picker uses AndroidX `EmojiPickerView`. To theme it correctly (it reads Material3 colour attributes) this bumps `com.google.android.material` `1.0.0 → 1.6.1` and adds `androidx.emoji2:emoji2-emojipicker`. It's shown in a themed, dismissible drawer that follows the app's day/night setting. Only Design-heritage material widgets are used elsewhere (AppBar/CollapsingToolbar/FAB/Snackbar), which don't require a MaterialComponents theme.

## Testing

Built and manually tested on a debug build across: reacting/un-reacting to text, image and audio messages; the gesture toggle; the ＋ emoji-grid picker (scroll, swipe-to-dismiss, day/night theming); recents and the configurable count; balanced wrapping; per-emoji counts; and round-tripping the Google-format reactions QUIK↔QUIK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
