### PR TITLE
feat(blocking): junk quarantine and JSON filter import

### DIFF
--- a/data/src/main/java/com/moez/QKSMS/migration/QkRealmMigration.kt
+++ b/data/src/main/java/com/moez/QKSMS/migration/QkRealmMigration.kt
@@ -37,7 +37,7 @@ class QkRealmMigration @Inject constructor(
 ) : RealmMigration {
 
     companion object {
-        const val SCHEMA_VERSION: Long = 15
+        const val SCHEMA_VERSION: Long = 16
     }
 
     @SuppressLint("ApplySharedPref")
@@ -298,6 +298,16 @@ class QkRealmMigration @Inject constructor(
             }
 
             version ++
+        }
+
+        if (version == 15L) {
+            if (realm.schema.get("Message")?.hasField("junk") == false) {
+                realm.schema.get("Message")
+                    ?.addField("junk", Boolean::class.java, FieldAttribute.REQUIRED)
+                    ?.transform { msg -> msg.setBoolean("junk", false) }
+            }
+
+            version++
         }
 
         check(version >= SCHEMA_VERSION) {

--- a/data/src/main/java/com/moez/QKSMS/repository/ConversationRepositoryImpl.kt
+++ b/data/src/main/java/com/moez/QKSMS/repository/ConversationRepositoryImpl.kt
@@ -375,6 +375,7 @@ class ConversationRepositoryImpl @Inject constructor(
                         conversation,
                         realm.where(Message::class.java)
                             .equalTo("threadId", conversation.id)
+                            .equalTo("junk", false)
                             .sort("date", Sort.DESCENDING)
                             .findFirst()
                     )
@@ -527,6 +528,7 @@ class ConversationRepositoryImpl @Inject constructor(
 
                             lastMessage = realm.where(Message::class.java)
                                 .equalTo("threadId", threadId)
+                                .equalTo("junk", false)
                                 .sort("date", Sort.DESCENDING)
                                 .findFirst()
                         }

--- a/data/src/main/java/com/moez/QKSMS/repository/ConversationRepositoryImpl.kt
+++ b/data/src/main/java/com/moez/QKSMS/repository/ConversationRepositoryImpl.kt
@@ -118,6 +118,7 @@ class ConversationRepositoryImpl @Inject constructor(
                     .thenByDescending { conversation ->
                         realm.where(Message::class.java)
                             .equalTo("threadId", conversation.id)
+                            .equalTo("junk", false)
                             .greaterThan(
                                 "date",
                                 System.currentTimeMillis() - TimeUnit.DAYS.toMillis(7)
@@ -154,6 +155,7 @@ class ConversationRepositoryImpl @Inject constructor(
 
         val messagesByConversation = realm.copyFromRealm(realm
             .where(Message::class.java)
+            .equalTo("junk", false)
             .beginGroup()
             .contains("body", searchQuery, Case.INSENSITIVE)
             .or()

--- a/data/src/main/java/com/moez/QKSMS/repository/MessageContentFilterRepositoryImpl.kt
+++ b/data/src/main/java/com/moez/QKSMS/repository/MessageContentFilterRepositoryImpl.kt
@@ -22,9 +22,17 @@ import dev.octoshrimpy.quik.model.MessageContentFilter
 import dev.octoshrimpy.quik.model.MessageContentFilterData
 import io.realm.Realm
 import io.realm.RealmResults
+import java.util.concurrent.ConcurrentHashMap
 import javax.inject.Inject
+import javax.inject.Singleton
 
+@Singleton
 class MessageContentFilterRepositoryImpl @Inject constructor() : MessageContentFilterRepository {
+
+    private data class Matcher(val regex: Regex, val lowercaseBody: Boolean)
+
+    private val matcherCache = ConcurrentHashMap<Long, Matcher>()
+
     override fun createFilter(data: MessageContentFilterData) {
         Realm.getDefaultInstance().use { realm ->
             realm.refresh()
@@ -59,20 +67,33 @@ class MessageContentFilterRepositoryImpl @Inject constructor() : MessageContentF
                 .any { filter ->
                     if (isContact && !filter.includeContacts) {
                         false
-                    } else if (filter.isRegex) {
-                        Regex(filter.value).matches(messageBody)
-                    } else if (filter.caseSensitive) {
-                        val regexp = "[\\s\\S]*\\b" + Regex.escape(filter.value) + "\\b[\\s\\S]*"
-                        Regex(regexp).matches(messageBody)
                     } else {
-                        val regexp = "[\\s\\S]*\\b" + Regex.escape(filter.value.lowercase()) + "\\b[\\s\\S]*"
-                        Regex(regexp).matches(messageBody.lowercase())
+                        val m = matcherCache.getOrPut(filter.id) { compileMatcher(filter) }
+                        val body = if (m.lowercaseBody) messageBody.lowercase() else messageBody
+                        m.regex.containsMatchIn(body)
                     }
                 }
         }
     }
 
+    private fun compileMatcher(filter: MessageContentFilter): Matcher = when {
+        filter.isRegex -> {
+            val opts = mutableSetOf(RegexOption.DOT_MATCHES_ALL)
+            if (!filter.caseSensitive) opts.add(RegexOption.IGNORE_CASE)
+            Matcher(Regex(filter.value, opts), lowercaseBody = false)
+        }
+        filter.caseSensitive -> {
+            val pattern = "\\b" + Regex.escape(filter.value) + "\\b"
+            Matcher(Regex(pattern), lowercaseBody = false)
+        }
+        else -> {
+            val pattern = "\\b" + Regex.escape(filter.value.lowercase()) + "\\b"
+            Matcher(Regex(pattern), lowercaseBody = true)
+        }
+    }
+
     override fun removeFilter(id: Long) {
+        matcherCache.remove(id)
         Realm.getDefaultInstance().use { realm ->
             realm.executeTransaction {
                 realm.where(MessageContentFilter::class.java)

--- a/data/src/main/java/com/moez/QKSMS/repository/MessageRepositoryImpl.kt
+++ b/data/src/main/java/com/moez/QKSMS/repository/MessageRepositoryImpl.kt
@@ -103,6 +103,7 @@ open class MessageRepositoryImpl @Inject constructor(
             .where(Message::class.java)
             .equalTo("threadId", threadId)
             .equalTo("isEmojiReaction", false)
+            .equalTo("junk", false)
             .let {
                 when (query.isEmpty()) {
                     true -> it
@@ -151,6 +152,7 @@ open class MessageRepositoryImpl @Inject constructor(
         Realm.getDefaultInstance()
             .where(Message::class.java)
             .equalTo("threadId", threadId)
+            .equalTo("junk", false)
             .beginGroup()
             .beginGroup()
             .equalTo("type", TYPE_SMS)
@@ -260,6 +262,7 @@ open class MessageRepositoryImpl @Inject constructor(
             .equalTo("seen", false)
             .equalTo("read", false)
             .equalTo("threadId", threadId)
+            .equalTo("junk", false)
             .sort("date")
             .findAll()
 
@@ -268,6 +271,7 @@ open class MessageRepositoryImpl @Inject constructor(
             .where(Message::class.java)
             .equalTo("read", false)
             .equalTo("threadId", threadId)
+            .equalTo("junk", false)
             .sort("date")
             .findAll()
 
@@ -996,6 +1000,37 @@ open class MessageRepositoryImpl @Inject constructor(
                     realm.executeTransaction { messages.deleteAllFromRealm() }
                 } ?: Unit
         }
+
+    override fun getJunkMessages(): RealmResults<Message> =
+        Realm.getDefaultInstance()
+            .where(Message::class.java)
+            .equalTo("junk", true)
+            .sort("date", Sort.DESCENDING)
+            .findAllAsync()
+
+    override fun markJunk(messageIds: Collection<Long>) {
+        Realm.getDefaultInstance().use { realm ->
+            realm.refresh()
+            realm.executeTransaction {
+                realm.where(Message::class.java)
+                    .anyOf("id", messageIds.toLongArray())
+                    .findAll()
+                    .forEach { it.junk = true }
+            }
+        }
+    }
+
+    override fun restoreJunk(messageIds: Collection<Long>) {
+        Realm.getDefaultInstance().use { realm ->
+            realm.refresh()
+            realm.executeTransaction {
+                realm.where(Message::class.java)
+                    .anyOf("id", messageIds.toLongArray())
+                    .findAll()
+                    .forEach { it.junk = false }
+            }
+        }
+    }
 
     override fun getOldMessageCounts(maxAgeDays: Int) =
         Realm.getDefaultInstance().use { realm ->

--- a/data/src/main/java/com/moez/QKSMS/repository/SyncRepositoryImpl.kt
+++ b/data/src/main/java/com/moez/QKSMS/repository/SyncRepositoryImpl.kt
@@ -112,6 +112,15 @@ class SyncRepositoryImpl @Inject constructor(
                         .findAll()
                 ).associateBy { conversation -> conversation.id }.toMutableMap()
 
+                val persistedJunk = realm.copyFromRealm(
+                    realm.where(Message::class.java)
+                        .equalTo("junk", true)
+                        .findAll()
+                ).mapNotNull { message ->
+                    if (message.contentId == 0L || message.type.isEmpty()) null
+                    else (message.type to message.contentId)
+                }.toHashSet()
+
                 removeOldMessages(realm)
 
                 keys.reset()
@@ -161,6 +170,7 @@ class SyncRepositoryImpl @Inject constructor(
                                         )
                                     }
                                 }
+                                junk = (type to contentId) in persistedJunk
                             }
                             realm.insertOrUpdate(message)
                         }
@@ -197,6 +207,7 @@ class SyncRepositoryImpl @Inject constructor(
                                     sendAsGroup = persistedConversation.sendAsGroup
                                 }
                                 lastMessage = realm.where(Message::class.java)
+                                    .equalTo("junk", false)
                                     .sort("date", Sort.DESCENDING)
                                     .equalTo("threadId", id)
                                     .findFirst()
@@ -287,8 +298,8 @@ class SyncRepositoryImpl @Inject constructor(
         // If we don't have a valid id, return null
         val contentId = tryOrNull(false) { ContentUris.parseId(uri) } ?: return null
 
-        // Check if the message already exists, so we can reuse the id
-        val existingId = Realm.getDefaultInstance().use { realm ->
+        // Check if the message already exists, so we can reuse the id and junk flag
+        val existing = Realm.getDefaultInstance().use { realm ->
             realm.refresh()
             realm.where(Message::class.java)
                 .equalTo("type", type)
@@ -300,8 +311,10 @@ class SyncRepositoryImpl @Inject constructor(
                 .equalTo("contentId", 0L)
                 .endGroup()
                 .findFirst()
-                ?.id
+                ?.let { message -> Pair(message.id, message.junk) }
         }
+        val existingId = existing?.first
+        val existingJunk = existing?.second == true
 
         // The uri might be something like content://mms/inbox/id
         // The box might change though, so we should just use the mms/id uri
@@ -318,6 +331,7 @@ class SyncRepositoryImpl @Inject constructor(
             val columnsMap = CursorToMessage.MessageColumns(cursor)
             cursorToMessage.map(Pair(cursor, columnsMap)).apply {
                 existingId?.let { this.id = it }
+                junk = existingJunk
 
                 if (isMms()) {
                     parts = RealmList<MmsPart>().apply {

--- a/data/src/main/java/com/moez/QKSMS/worker/ReceiveMmsWorker.kt
+++ b/data/src/main/java/com/moez/QKSMS/worker/ReceiveMmsWorker.kt
@@ -189,8 +189,13 @@ class ReceiveMmsWorker(appContext: Context, workerParams: WorkerParameters)
 
                         val messageFilterAction = filterRepo.isBlocked(message.getText(), message.address, contactsRepo)
                         if (messageFilterAction) {
-                            Timber.v("message dropped based on content filters")
-                            messageRepo.deleteMessages(listOf(message.id))
+                            if (prefs.drop.get()) {
+                                Timber.v("message dropped based on content filters")
+                                messageRepo.deleteMessages(listOf(message.id))
+                            } else {
+                                Timber.v("message marked as junk based on content filters")
+                                messageRepo.markJunk(listOf(message.id))
+                            }
                             return Result.failure(inputData)
                         }
 

--- a/data/src/main/java/com/moez/QKSMS/worker/ReceiveSmsWorker.kt
+++ b/data/src/main/java/com/moez/QKSMS/worker/ReceiveSmsWorker.kt
@@ -91,8 +91,13 @@ class ReceiveSmsWorker(appContext: Context, workerParams: WorkerParameters)
 
         val messageFilterAction = filterRepo.isBlocked(message.getText(), message.address, contactsRepo)
         if (messageFilterAction) {
-            Timber.v("message dropped based on content filters")
-            messageRepo.deleteMessages(listOf(message.id))
+            if (prefs.drop.get()) {
+                Timber.v("message dropped based on content filters")
+                messageRepo.deleteMessages(listOf(message.id))
+            } else {
+                Timber.v("message marked as junk based on content filters")
+                messageRepo.markJunk(listOf(message.id))
+            }
             return Result.failure(inputData)
         }
 

--- a/domain/src/main/java/com/moez/QKSMS/model/Message.kt
+++ b/domain/src/main/java/com/moez/QKSMS/model/Message.kt
@@ -83,6 +83,8 @@ open class Message : RealmObject() {
 
     var sendAsGroup: Boolean = false
 
+    var junk: Boolean = false
+
     fun getUri(): Uri {
         if (contentId == 0L)
             return Uri.EMPTY

--- a/domain/src/main/java/com/moez/QKSMS/repository/MessageRepository.kt
+++ b/domain/src/main/java/com/moez/QKSMS/repository/MessageRepository.kt
@@ -99,6 +99,12 @@ interface MessageRepository {
 
     fun deleteMessages(messageIds: Collection<Long>)
 
+    fun getJunkMessages(): RealmResults<Message>
+
+    fun markJunk(messageIds: Collection<Long>)
+
+    fun restoreJunk(messageIds: Collection<Long>)
+
     fun getOldMessageCounts(maxAgeDays: Int): Map<Long, Int>
 
     fun deleteOldMessages(maxAgeDays: Int)

--- a/metadata/en-US/changelogs/2239.txt
+++ b/metadata/en-US/changelogs/2239.txt
@@ -1,5 +1,0 @@
-# What's Changed
-- New Junk screen (Settings > Blocking > Junk) to quarantine messages caught by content filters instead of dropping them, when Drop is off
-- Import content filters from JSON
-- Fix regex filters not matching anywhere in message body
-- Regex filters now honor case-sensitive flag

--- a/metadata/en-US/changelogs/2239.txt
+++ b/metadata/en-US/changelogs/2239.txt
@@ -1,0 +1,5 @@
+# What's Changed
+- New Junk screen (Settings > Blocking > Junk) to quarantine messages caught by content filters instead of dropping them, when Drop is off
+- Import content filters from JSON
+- Fix regex filters not matching anywhere in message body
+- Regex filters now honor case-sensitive flag

--- a/presentation/build.gradle
+++ b/presentation/build.gradle
@@ -28,8 +28,8 @@ android {
         applicationId 'dev.octoshrimpy.quik'
         minSdkVersion 23
         targetSdkVersion 33
-        versionCode 2239
-        versionName '4.4.0'
+        versionCode 2238
+        versionName '4.3.6'
         setProperty("archivesBaseName", "QUIK-v${versionName}")
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/presentation/build.gradle
+++ b/presentation/build.gradle
@@ -28,8 +28,8 @@ android {
         applicationId 'dev.octoshrimpy.quik'
         minSdkVersion 23
         targetSdkVersion 33
-        versionCode 2238
-        versionName '4.3.6'
+        versionCode 2239
+        versionName '4.4.0'
         setProperty("archivesBaseName", "QUIK-v${versionName}")
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/presentation/src/main/java/com/moez/QKSMS/feature/blocking/BlockingActivity.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/feature/blocking/BlockingActivity.kt
@@ -18,6 +18,7 @@
  */
 package dev.octoshrimpy.quik.feature.blocking
 
+import android.net.Uri
 import android.os.Bundle
 import com.bluelinelabs.conductor.Conductor
 import com.bluelinelabs.conductor.Router
@@ -25,12 +26,19 @@ import com.bluelinelabs.conductor.RouterTransaction
 import dagger.android.AndroidInjection
 import dev.octoshrimpy.quik.R
 import dev.octoshrimpy.quik.common.base.QkThemedActivity
+import dev.octoshrimpy.quik.common.util.QkActivityResultContracts
 import dev.octoshrimpy.quik.databinding.ContainerActivityBinding
 
 class BlockingActivity : QkThemedActivity() {
 
     private lateinit var router: Router
     private lateinit var binding: ContainerActivityBinding
+
+    var importDocumentCallback: ((Uri) -> Unit)? = null
+
+    val openDocument = registerForActivityResult(QkActivityResultContracts.OpenDocument()) { uri ->
+        if (uri != null && uri != Uri.EMPTY) importDocumentCallback?.invoke(uri)
+    }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         AndroidInjection.inject(this)

--- a/presentation/src/main/java/com/moez/QKSMS/feature/blocking/BlockingController.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/feature/blocking/BlockingController.kt
@@ -32,6 +32,7 @@ import dev.octoshrimpy.quik.feature.blocking.manager.BlockingManagerController
 import dev.octoshrimpy.quik.feature.blocking.messages.BlockedMessagesController
 import dev.octoshrimpy.quik.feature.blocking.numbers.BlockedNumbersController
 import dev.octoshrimpy.quik.feature.blocking.filters.MessageContentFiltersController
+import dev.octoshrimpy.quik.feature.blocking.junk.JunkController
 import dev.octoshrimpy.quik.injection.appComponent
 import dev.octoshrimpy.quik.databinding.BlockingControllerBinding
 import javax.inject.Inject
@@ -45,6 +46,7 @@ class BlockingController : QkController<BlockingControllerBinding, BlockingView,
     override val blockedNumbersIntent get() = binding.blockedNumbers.clicks()
     override val messageContentFiltersIntent get() = binding.messageContentFilters.clicks()
     override val blockedMessagesIntent get() = binding.blockedMessages.clicks()
+    override val junkIntent get() = binding.junk.clicks()
     override val dropClickedIntent get() = binding.drop.clicks()
 
     @Inject lateinit var colors: Colors
@@ -71,6 +73,7 @@ class BlockingController : QkController<BlockingControllerBinding, BlockingView,
         binding.blockingManager.summary = state.blockingManager
         binding.drop.checkbox?.isChecked = state.dropEnabled
         binding.blockedMessages.isEnabled = !state.dropEnabled
+        binding.junk.isEnabled = !state.dropEnabled
     }
 
     override fun openBlockedNumbers() {
@@ -93,6 +96,12 @@ class BlockingController : QkController<BlockingControllerBinding, BlockingView,
 
     override fun openBlockingManager() {
         router.pushController(RouterTransaction.with(BlockingManagerController())
+                .pushChangeHandler(QkChangeHandler())
+                .popChangeHandler(QkChangeHandler()))
+    }
+
+    override fun openJunk() {
+        router.pushController(RouterTransaction.with(JunkController())
                 .pushChangeHandler(QkChangeHandler())
                 .popChangeHandler(QkChangeHandler()))
     }

--- a/presentation/src/main/java/com/moez/QKSMS/feature/blocking/BlockingPresenter.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/feature/blocking/BlockingPresenter.kt
@@ -77,6 +77,10 @@ class BlockingPresenter @Inject constructor(
                 .autoDisposable(view.scope())
                 .subscribe { view.openBlockedMessages() }
 
+        view.junkIntent
+                .autoDisposable(view.scope())
+                .subscribe { view.openJunk() }
+
         view.dropClickedIntent
                 .autoDisposable(view.scope())
                 .subscribe { prefs.drop.set(!prefs.drop.get()) }

--- a/presentation/src/main/java/com/moez/QKSMS/feature/blocking/BlockingView.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/feature/blocking/BlockingView.kt
@@ -27,10 +27,12 @@ interface BlockingView : QkViewContract<BlockingState> {
     val blockedNumbersIntent: Observable<*>
     val messageContentFiltersIntent: Observable<*>
     val blockedMessagesIntent: Observable<*>
+    val junkIntent: Observable<*>
     val dropClickedIntent: Observable<*>
 
     fun openBlockingManager()
     fun openBlockedNumbers()
     fun openMessageContentFilters()
     fun openBlockedMessages()
+    fun openJunk()
 }

--- a/presentation/src/main/java/com/moez/QKSMS/feature/blocking/filters/MessageContentFiltersController.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/feature/blocking/filters/MessageContentFiltersController.kt
@@ -18,7 +18,11 @@
  */
 package dev.octoshrimpy.quik.feature.blocking.filters
 
+import android.net.Uri
 import android.view.LayoutInflater
+import android.view.Menu
+import android.view.MenuInflater
+import android.view.MenuItem
 import android.view.View
 import androidx.appcompat.app.AlertDialog
 import com.jakewharton.rxbinding2.view.clicks
@@ -27,9 +31,11 @@ import com.uber.autodispose.autoDisposable
 import dev.octoshrimpy.quik.R
 import dev.octoshrimpy.quik.common.base.QkController
 import dev.octoshrimpy.quik.common.util.Colors
+import dev.octoshrimpy.quik.common.util.QkActivityResultContracts
 import dev.octoshrimpy.quik.common.util.extensions.setBackgroundTint
 import dev.octoshrimpy.quik.common.util.extensions.setTint
 import dev.octoshrimpy.quik.common.widget.PreferenceView
+import dev.octoshrimpy.quik.feature.blocking.BlockingActivity
 import dev.octoshrimpy.quik.injection.appComponent
 import dev.octoshrimpy.quik.model.MessageContentFilterData
 import dev.octoshrimpy.quik.databinding.MessageContentFiltersControllerBinding
@@ -47,6 +53,8 @@ class MessageContentFiltersController : QkController<MessageContentFiltersContro
 
     private val adapter = MessageContentFiltersAdapter()
     private val saveFilterSubject: Subject<MessageContentFilterData> = PublishSubject.create()
+    private val importClickSubject: Subject<Unit> = PublishSubject.create()
+    private val importFileSelectedSubject: Subject<Uri> = PublishSubject.create()
 
     init {
         appComponent.inject(this)
@@ -61,6 +69,20 @@ class MessageContentFiltersController : QkController<MessageContentFiltersContro
         presenter.bindIntents(this)
         setTitle(R.string.message_content_filters_title)
         showBackButton(true)
+        setHasOptionsMenu(true)
+    }
+
+    override fun onCreateOptionsMenu(menu: Menu, inflater: MenuInflater) {
+        super.onCreateOptionsMenu(menu, inflater)
+        inflater.inflate(R.menu.message_content_filters, menu)
+    }
+
+    override fun onOptionsItemSelected(item: MenuItem): Boolean {
+        if (item.itemId == R.id.import_json) {
+            importClickSubject.onNext(Unit)
+            return true
+        }
+        return super.onOptionsItemSelected(item)
     }
 
     override fun onViewCreated() {
@@ -78,6 +100,47 @@ class MessageContentFiltersController : QkController<MessageContentFiltersContro
     override fun removeFilter(): Observable<Long> = adapter.removeMessageContentFilter
     override fun addFilter(): Observable<*> = binding.add.clicks()
     override fun saveFilter(): Observable<MessageContentFilterData> = saveFilterSubject
+    override fun importClicks(): Observable<*> = importClickSubject
+    override fun importFileSelected(): Observable<Uri> = importFileSelectedSubject
+
+    override fun selectImportFile() {
+        val host = activity as BlockingActivity
+        host.importDocumentCallback = { uri ->
+            importFileSelectedSubject.onNext(uri)
+            host.importDocumentCallback = null
+        }
+        host.openDocument.launch(QkActivityResultContracts.OpenDocumentParams(
+            mimeTypes = listOf("application/json", "text/plain", "application/octet-stream")
+        ))
+    }
+
+    override fun showImportResult(imported: Int, skipped: Int) {
+        AlertDialog.Builder(activity!!)
+            .setTitle(R.string.message_content_filters_import_result_title)
+            .setMessage(resources!!.getQuantityString(
+                R.plurals.message_content_filters_import_result,
+                imported, imported, skipped
+            ))
+            .setPositiveButton(android.R.string.ok, null)
+            .show()
+    }
+
+    override fun showImportError() {
+        AlertDialog.Builder(activity!!)
+            .setTitle(R.string.message_content_filters_import_error_title)
+            .setMessage(R.string.message_content_filters_import_error)
+            .setPositiveButton(android.R.string.ok, null)
+            .show()
+    }
+
+    override fun showRegexErrors(phrases: List<String>) {
+        val message = phrases.joinToString(separator = "\n") { "• $it" }
+        AlertDialog.Builder(activity!!)
+            .setTitle(R.string.message_content_filters_import_regex_errors_title)
+            .setMessage(message)
+            .setPositiveButton(android.R.string.ok, null)
+            .show()
+    }
 
     override fun showAddDialog() {
         val layout = MessageContentFiltersAddDialogBinding.inflate(LayoutInflater.from(activity))

--- a/presentation/src/main/java/com/moez/QKSMS/feature/blocking/filters/MessageContentFiltersPresenter.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/feature/blocking/filters/MessageContentFiltersPresenter.kt
@@ -18,18 +18,41 @@
  */
 package dev.octoshrimpy.quik.feature.blocking.filters
 
+import android.content.Context
+import android.net.Uri
 import com.uber.autodispose.android.lifecycle.scope
 import com.uber.autodispose.autoDisposable
 import dev.octoshrimpy.quik.common.base.QkPresenter
+import dev.octoshrimpy.quik.model.MessageContentFilterData
 import dev.octoshrimpy.quik.repository.MessageContentFilterRepository
+import io.reactivex.android.schedulers.AndroidSchedulers
 import io.reactivex.schedulers.Schedulers
+import org.json.JSONArray
+import java.io.ByteArrayOutputStream
+import java.util.concurrent.Callable
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
 import javax.inject.Inject
 
 class MessageContentFiltersPresenter @Inject constructor(
+    private val context: Context,
     private val filterRepo: MessageContentFilterRepository,
 ) : QkPresenter<MessageContentFiltersView, MessageContentFiltersState>(
         MessageContentFiltersState(filters = filterRepo.getMessageContentFilters())
 ) {
+
+    companion object {
+        // Filter lists are realistically kilobytes. Cap the read so a huge or
+        // malicious SAF payload cannot force an OutOfMemoryError on the process.
+        private const val MAX_FILE_BYTES = 1_048_576
+        private const val MAX_PHRASE_LEN = 4096
+        private const val MAX_ENTRIES = 10_000
+        // ReDoS probe: run each imported regex against a pathological input on
+        // a bounded timeout. Catastrophic backtracking that would otherwise
+        // freeze the SMS receive worker gets caught at import time instead.
+        private const val REDOS_PROBE = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa!"
+        private const val REDOS_TIMEOUT_MS = 200L
+    }
 
     override fun bindIntents(view: MessageContentFiltersView) {
         super.bindIntents(view)
@@ -50,6 +73,115 @@ class MessageContentFiltersPresenter @Inject constructor(
             .subscribeOn(Schedulers.io())
             .autoDisposable(view.scope())
             .subscribe { filterData -> filterRepo.createFilter(filterData) }
+
+        view.importClicks()
+            .autoDisposable(view.scope())
+            .subscribe { view.selectImportFile() }
+
+        view.importFileSelected()
+            .observeOn(Schedulers.io())
+            .map { uri -> importFromUri(uri) }
+            .observeOn(AndroidSchedulers.mainThread())
+            .autoDisposable(view.scope())
+            .subscribe { result ->
+                when (result) {
+                    is ImportResult.Success -> {
+                        view.showImportResult(result.imported, result.skipped)
+                        if (result.regexErrors.isNotEmpty()) view.showRegexErrors(result.regexErrors)
+                    }
+                    is ImportResult.Failure -> view.showImportError()
+                }
+            }
+    }
+
+    private sealed class ImportResult {
+        data class Success(
+            val imported: Int,
+            val skipped: Int,
+            val regexErrors: List<String>
+        ) : ImportResult()
+        object Failure : ImportResult()
+    }
+
+    private fun readBounded(uri: Uri, maxBytes: Int): String? {
+        return try {
+            context.contentResolver.openInputStream(uri)?.use { input ->
+                val out = ByteArrayOutputStream()
+                val buf = ByteArray(8192)
+                var total = 0
+                while (true) {
+                    val n = input.read(buf)
+                    if (n < 0) break
+                    total += n
+                    if (total > maxBytes) return@use null
+                    out.write(buf, 0, n)
+                }
+                out.toString(Charsets.UTF_8.name())
+            }
+        } catch (t: Throwable) {
+            null
+        }
+    }
+
+    private fun regexIsSafe(value: String): Boolean {
+        val executor = Executors.newSingleThreadExecutor()
+        return try {
+            val opts = setOf(RegexOption.DOT_MATCHES_ALL, RegexOption.IGNORE_CASE)
+            val regex = Regex(value, opts)
+            val future = executor.submit(Callable { regex.containsMatchIn(REDOS_PROBE) })
+            future.get(REDOS_TIMEOUT_MS, TimeUnit.MILLISECONDS)
+            true
+        } catch (t: Throwable) {
+            false
+        } finally {
+            executor.shutdownNow()
+        }
+    }
+
+    private fun importFromUri(uri: Uri): ImportResult {
+        val payload = readBounded(uri, MAX_FILE_BYTES) ?: return ImportResult.Failure
+
+        val array = try {
+            JSONArray(payload)
+        } catch (t: Throwable) {
+            return ImportResult.Failure
+        }
+
+        var imported = 0
+        var skipped = 0
+        val regexErrors = mutableListOf<String>()
+        val entries = minOf(array.length(), MAX_ENTRIES)
+        for (i in 0 until entries) {
+            val entry = array.optJSONObject(i)
+            if (entry == null) {
+                skipped++
+                continue
+            }
+            val action = entry.optString("action", "")
+            val phrase = entry.optString("phrase", "")
+            if (action != "junk" || phrase.isBlank() || phrase.length > MAX_PHRASE_LEN) {
+                skipped++
+                continue
+            }
+            val useRegex = entry.optBoolean("useRegex", false)
+            val caseSensitive = entry.optBoolean("caseSensitive", false) && !useRegex
+            val value = if (useRegex) phrase else phrase.trim()
+            if (useRegex && !regexIsSafe(value)) {
+                regexErrors.add(value)
+                skipped++
+                continue
+            }
+            filterRepo.createFilter(
+                MessageContentFilterData(
+                    value = value,
+                    caseSensitive = caseSensitive,
+                    isRegex = useRegex,
+                    includeContacts = false
+                )
+            )
+            imported++
+        }
+        return ImportResult.Success(imported, skipped, regexErrors)
     }
 
 }

--- a/presentation/src/main/java/com/moez/QKSMS/feature/blocking/filters/MessageContentFiltersPresenter.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/feature/blocking/filters/MessageContentFiltersPresenter.kt
@@ -30,8 +30,10 @@ import io.reactivex.schedulers.Schedulers
 import org.json.JSONArray
 import java.io.ByteArrayOutputStream
 import java.util.concurrent.Callable
+import java.util.concurrent.ExecutorService
 import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
+import java.util.concurrent.TimeoutException
 import javax.inject.Inject
 
 class MessageContentFiltersPresenter @Inject constructor(
@@ -123,18 +125,27 @@ class MessageContentFiltersPresenter @Inject constructor(
         }
     }
 
-    private fun regexIsSafe(value: String): Boolean {
-        val executor = Executors.newSingleThreadExecutor()
-        return try {
-            val opts = setOf(RegexOption.DOT_MATCHES_ALL, RegexOption.IGNORE_CASE)
-            val regex = Regex(value, opts)
-            val future = executor.submit(Callable { regex.containsMatchIn(REDOS_PROBE) })
-            future.get(REDOS_TIMEOUT_MS, TimeUnit.MILLISECONDS)
-            true
+    private enum class ProbeResult { Ok, Unsafe, Timeout }
+
+    // java.util.regex does not honour thread interrupts, so a runaway
+    // backtrack keeps its executor thread pinned even after cancel(true).
+    // Reuse one executor for the whole import; on timeout, orphan it and
+    // spin up a fresh one for the next probe.
+    private fun probeRegex(executor: ExecutorService, value: String): ProbeResult {
+        val regex = try {
+            Regex(value, setOf(RegexOption.DOT_MATCHES_ALL, RegexOption.IGNORE_CASE))
         } catch (t: Throwable) {
-            false
-        } finally {
-            executor.shutdownNow()
+            return ProbeResult.Unsafe
+        }
+        val future = executor.submit(Callable { regex.containsMatchIn(REDOS_PROBE) })
+        return try {
+            future.get(REDOS_TIMEOUT_MS, TimeUnit.MILLISECONDS)
+            ProbeResult.Ok
+        } catch (t: TimeoutException) {
+            future.cancel(true)
+            ProbeResult.Timeout
+        } catch (t: Throwable) {
+            ProbeResult.Unsafe
         }
     }
 
@@ -151,35 +162,54 @@ class MessageContentFiltersPresenter @Inject constructor(
         var skipped = 0
         val regexErrors = mutableListOf<String>()
         val entries = minOf(array.length(), MAX_ENTRIES)
-        for (i in 0 until entries) {
-            val entry = array.optJSONObject(i)
-            if (entry == null) {
-                skipped++
-                continue
-            }
-            val action = entry.optString("action", "")
-            val phrase = entry.optString("phrase", "")
-            if (action != "junk" || phrase.isBlank() || phrase.length > MAX_PHRASE_LEN) {
-                skipped++
-                continue
-            }
-            val useRegex = entry.optBoolean("useRegex", false)
-            val caseSensitive = entry.optBoolean("caseSensitive", false) && !useRegex
-            val value = if (useRegex) phrase else phrase.trim()
-            if (useRegex && !regexIsSafe(value)) {
-                regexErrors.add(value)
-                skipped++
-                continue
-            }
-            filterRepo.createFilter(
-                MessageContentFilterData(
-                    value = value,
-                    caseSensitive = caseSensitive,
-                    isRegex = useRegex,
-                    includeContacts = false
+        var probeExecutor: ExecutorService? = null
+        try {
+            for (i in 0 until entries) {
+                val entry = array.optJSONObject(i)
+                if (entry == null) {
+                    skipped++
+                    continue
+                }
+                val action = entry.optString("action", "")
+                val phrase = entry.optString("phrase", "")
+                if (action != "junk" || phrase.isBlank() || phrase.length > MAX_PHRASE_LEN) {
+                    skipped++
+                    continue
+                }
+                val useRegex = entry.optBoolean("useRegex", false)
+                val caseSensitive = entry.optBoolean("caseSensitive", false) && !useRegex
+                val value = if (useRegex) phrase else phrase.trim()
+                if (useRegex) {
+                    val executor = probeExecutor
+                        ?: Executors.newSingleThreadExecutor().also { probeExecutor = it }
+                    when (probeRegex(executor, value)) {
+                        ProbeResult.Ok -> Unit
+                        ProbeResult.Unsafe -> {
+                            regexErrors.add(value)
+                            skipped++
+                            continue
+                        }
+                        ProbeResult.Timeout -> {
+                            executor.shutdownNow()
+                            probeExecutor = null
+                            regexErrors.add(value)
+                            skipped++
+                            continue
+                        }
+                    }
+                }
+                filterRepo.createFilter(
+                    MessageContentFilterData(
+                        value = value,
+                        caseSensitive = caseSensitive,
+                        isRegex = useRegex,
+                        includeContacts = false
+                    )
                 )
-            )
-            imported++
+                imported++
+            }
+        } finally {
+            probeExecutor?.shutdownNow()
         }
         return ImportResult.Success(imported, skipped, regexErrors)
     }

--- a/presentation/src/main/java/com/moez/QKSMS/feature/blocking/filters/MessageContentFiltersView.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/feature/blocking/filters/MessageContentFiltersView.kt
@@ -18,6 +18,7 @@
  */
 package dev.octoshrimpy.quik.feature.blocking.filters
 
+import android.net.Uri
 import dev.octoshrimpy.quik.common.base.QkViewContract
 import dev.octoshrimpy.quik.model.MessageContentFilterData
 import io.reactivex.Observable
@@ -27,7 +28,13 @@ interface MessageContentFiltersView : QkViewContract<MessageContentFiltersState>
     fun removeFilter(): Observable<Long>
     fun addFilter(): Observable<*>
     fun saveFilter(): Observable<MessageContentFilterData>
+    fun importClicks(): Observable<*>
+    fun importFileSelected(): Observable<Uri>
 
     fun showAddDialog()
+    fun selectImportFile()
+    fun showImportResult(imported: Int, skipped: Int)
+    fun showImportError()
+    fun showRegexErrors(phrases: List<String>)
 
 }

--- a/presentation/src/main/java/com/moez/QKSMS/feature/blocking/junk/JunkAdapter.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/feature/blocking/junk/JunkAdapter.kt
@@ -1,0 +1,55 @@
+/*
+ * Copyright (C) 2025
+ *
+ * This file is part of QUIK.
+ *
+ * QUIK is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ */
+package dev.octoshrimpy.quik.feature.blocking.junk
+
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import dev.octoshrimpy.quik.common.base.QkBindingViewHolder
+import dev.octoshrimpy.quik.common.base.QkRealmAdapter
+import dev.octoshrimpy.quik.common.util.DateFormatter
+import dev.octoshrimpy.quik.databinding.JunkListItemBinding
+import dev.octoshrimpy.quik.model.Message
+import javax.inject.Inject
+
+class JunkAdapter @Inject constructor(
+    private val dateFormatter: DateFormatter
+) : QkRealmAdapter<Message, QkBindingViewHolder<JunkListItemBinding>>() {
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): QkBindingViewHolder<JunkListItemBinding> {
+        val binding = JunkListItemBinding.inflate(LayoutInflater.from(parent.context), parent, false)
+        return QkBindingViewHolder(binding).apply {
+            binding.root.setOnClickListener {
+                val message = getItem(adapterPosition) ?: return@setOnClickListener
+                if (toggleSelection(message.id, force = false)) {
+                    binding.root.isActivated = isSelected(message.id)
+                }
+            }
+            binding.root.setOnLongClickListener {
+                val message = getItem(adapterPosition) ?: return@setOnLongClickListener true
+                toggleSelection(message.id)
+                binding.root.isActivated = isSelected(message.id)
+                true
+            }
+        }
+    }
+
+    override fun onBindViewHolder(holder: QkBindingViewHolder<JunkListItemBinding>, position: Int) {
+        val message = getItem(position) ?: return
+        val binding = holder.binding
+
+        holder.itemView.isActivated = isSelected(message.id)
+
+        binding.address.text = message.address
+        binding.date.text = dateFormatter.getConversationTimestamp(message.date)
+        binding.body.text = message.getText()
+    }
+
+}

--- a/presentation/src/main/java/com/moez/QKSMS/feature/blocking/junk/JunkController.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/feature/blocking/junk/JunkController.kt
@@ -1,0 +1,113 @@
+/*
+ * Copyright (C) 2025
+ *
+ * This file is part of QUIK.
+ *
+ * QUIK is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ */
+package dev.octoshrimpy.quik.feature.blocking.junk
+
+import android.content.Context
+import android.view.LayoutInflater
+import android.view.Menu
+import android.view.MenuInflater
+import android.view.MenuItem
+import android.view.View
+import android.view.ViewGroup
+import androidx.appcompat.app.AlertDialog
+import androidx.appcompat.widget.Toolbar
+import dev.octoshrimpy.quik.R
+import dev.octoshrimpy.quik.common.base.QkController
+import dev.octoshrimpy.quik.databinding.JunkControllerBinding
+import dev.octoshrimpy.quik.injection.appComponent
+import io.reactivex.Observable
+import io.reactivex.subjects.PublishSubject
+import io.reactivex.subjects.Subject
+import javax.inject.Inject
+
+class JunkController : QkController<JunkControllerBinding, JunkView, JunkState, JunkPresenter>(),
+    JunkView {
+
+    override fun inflateBinding(inflater: LayoutInflater, container: ViewGroup): JunkControllerBinding =
+        JunkControllerBinding.inflate(inflater, container, false)
+
+    override val menuReadyIntent: Subject<Unit> = PublishSubject.create()
+    override val optionsItemIntent: Subject<Int> = PublishSubject.create()
+    override val selectionChanges: Observable<List<Long>> by lazy { adapter.selectionChanges }
+    override val confirmDeleteIntent: Subject<List<Long>> = PublishSubject.create()
+    override val backClicked: Subject<Unit> = PublishSubject.create()
+
+    @Inject lateinit var adapter: JunkAdapter
+    @Inject lateinit var context: Context
+    @Inject override lateinit var presenter: JunkPresenter
+
+    init {
+        appComponent.inject(this)
+        retainViewMode = RetainViewMode.RETAIN_DETACH
+    }
+
+    override fun onViewCreated() {
+        super.onViewCreated()
+        adapter.emptyView = binding.empty
+        binding.messages.adapter = adapter
+    }
+
+    override fun onAttach(view: View) {
+        super.onAttach(view)
+        presenter.bindIntents(this)
+        setTitle(R.string.junk_title)
+        showBackButton(true)
+        setHasOptionsMenu(true)
+    }
+
+    override fun onCreateOptionsMenu(menu: Menu, inflater: MenuInflater) {
+        super.onCreateOptionsMenu(menu, inflater)
+        inflater.inflate(R.menu.junk, menu)
+        menuReadyIntent.onNext(Unit)
+    }
+
+    override fun onOptionsItemSelected(item: MenuItem): Boolean {
+        optionsItemIntent.onNext(item.itemId)
+        return true
+    }
+
+    override fun handleBack(): Boolean {
+        backClicked.onNext(Unit)
+        return true
+    }
+
+    override fun render(state: JunkState) {
+        adapter.updateData(state.data)
+
+        val toolbarMenu = themedActivity?.findViewById<Toolbar>(R.id.toolbar)?.menu
+        toolbarMenu?.findItem(R.id.restore)?.isVisible = state.selected > 0
+        toolbarMenu?.findItem(R.id.delete)?.isVisible = state.selected > 0
+
+        setTitle(when (state.selected) {
+            0 -> context.getString(R.string.junk_title)
+            else -> context.getString(R.string.main_title_selected, state.selected)
+        })
+    }
+
+    override fun clearSelection() = adapter.clearSelection()
+
+    override fun showDeleteDialog(messageIds: List<Long>) {
+        val count = messageIds.size
+        AlertDialog.Builder(activity!!)
+            .setTitle(R.string.junk_delete_dialog_title)
+            .setMessage(resources!!.getQuantityString(
+                R.plurals.junk_delete_dialog_message, count, count
+            ))
+            .setPositiveButton(R.string.button_delete) { _, _ -> confirmDeleteIntent.onNext(messageIds) }
+            .setNegativeButton(R.string.button_cancel, null)
+            .show()
+    }
+
+    override fun goBack() {
+        router.popCurrentController()
+    }
+
+}

--- a/presentation/src/main/java/com/moez/QKSMS/feature/blocking/junk/JunkPresenter.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/feature/blocking/junk/JunkPresenter.kt
@@ -14,11 +14,14 @@ import com.uber.autodispose.android.lifecycle.scope
 import com.uber.autodispose.autoDisposable
 import dev.octoshrimpy.quik.R
 import dev.octoshrimpy.quik.common.base.QkPresenter
+import dev.octoshrimpy.quik.extensions.anyOf
+import dev.octoshrimpy.quik.model.Message
 import dev.octoshrimpy.quik.repository.ConversationRepository
 import dev.octoshrimpy.quik.repository.MessageRepository
 import io.reactivex.android.schedulers.AndroidSchedulers
 import io.reactivex.rxkotlin.withLatestFrom
 import io.reactivex.schedulers.Schedulers
+import io.realm.Realm
 import javax.inject.Inject
 
 class JunkPresenter @Inject constructor(
@@ -40,7 +43,13 @@ class JunkPresenter @Inject constructor(
                 when (itemId) {
                     R.id.restore -> {
                         Schedulers.io().scheduleDirect {
-                            val threadIds = messageRepo.getMessages(ids).map { it.threadId }.toSet()
+                            val threadIds = Realm.getDefaultInstance().use { realm ->
+                                realm.where(Message::class.java)
+                                    .anyOf("id", ids.toLongArray())
+                                    .findAll()
+                                    .map { it.threadId }
+                                    .toSet()
+                            }
                             messageRepo.restoreJunk(ids)
                             if (threadIds.isNotEmpty()) conversationRepo.updateConversations(threadIds)
                         }

--- a/presentation/src/main/java/com/moez/QKSMS/feature/blocking/junk/JunkPresenter.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/feature/blocking/junk/JunkPresenter.kt
@@ -1,0 +1,77 @@
+/*
+ * Copyright (C) 2025
+ *
+ * This file is part of QUIK.
+ *
+ * QUIK is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ */
+package dev.octoshrimpy.quik.feature.blocking.junk
+
+import com.uber.autodispose.android.lifecycle.scope
+import com.uber.autodispose.autoDisposable
+import dev.octoshrimpy.quik.R
+import dev.octoshrimpy.quik.common.base.QkPresenter
+import dev.octoshrimpy.quik.repository.ConversationRepository
+import dev.octoshrimpy.quik.repository.MessageRepository
+import io.reactivex.android.schedulers.AndroidSchedulers
+import io.reactivex.rxkotlin.withLatestFrom
+import io.reactivex.schedulers.Schedulers
+import javax.inject.Inject
+
+class JunkPresenter @Inject constructor(
+    private val conversationRepo: ConversationRepository,
+    private val messageRepo: MessageRepository
+) : QkPresenter<JunkView, JunkState>(JunkState(
+    data = messageRepo.getJunkMessages()
+)) {
+
+    override fun bindIntents(view: JunkView) {
+        super.bindIntents(view)
+
+        view.menuReadyIntent
+            .autoDisposable(view.scope())
+            .subscribe { newState { copy() } }
+
+        view.optionsItemIntent
+            .withLatestFrom(view.selectionChanges) { itemId, ids ->
+                when (itemId) {
+                    R.id.restore -> {
+                        Schedulers.io().scheduleDirect {
+                            val threadIds = messageRepo.getMessages(ids).map { it.threadId }.toSet()
+                            messageRepo.restoreJunk(ids)
+                            if (threadIds.isNotEmpty()) conversationRepo.updateConversations(threadIds)
+                        }
+                        view.clearSelection()
+                    }
+                    R.id.delete -> view.showDeleteDialog(ids)
+                }
+            }
+            .autoDisposable(view.scope())
+            .subscribe()
+
+        view.confirmDeleteIntent
+            .observeOn(Schedulers.io())
+            .doOnNext { ids -> messageRepo.deleteMessages(ids) }
+            .observeOn(AndroidSchedulers.mainThread())
+            .autoDisposable(view.scope())
+            .subscribe { view.clearSelection() }
+
+        view.selectionChanges
+            .autoDisposable(view.scope())
+            .subscribe { selection -> newState { copy(selected = selection.size) } }
+
+        view.backClicked
+            .withLatestFrom(state) { _, state ->
+                when (state.selected) {
+                    0 -> view.goBack()
+                    else -> view.clearSelection()
+                }
+            }
+            .autoDisposable(view.scope())
+            .subscribe()
+    }
+
+}

--- a/presentation/src/main/java/com/moez/QKSMS/feature/blocking/junk/JunkPresenter.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/feature/blocking/junk/JunkPresenter.kt
@@ -51,6 +51,9 @@ class JunkPresenter @Inject constructor(
                                     .toSet()
                             }
                             messageRepo.restoreJunk(ids)
+                            threadIds.forEach { threadId ->
+                                conversationRepo.getOrCreateConversation(threadId)
+                            }
                             if (threadIds.isNotEmpty()) conversationRepo.updateConversations(threadIds)
                         }
                         view.clearSelection()

--- a/presentation/src/main/java/com/moez/QKSMS/feature/blocking/junk/JunkState.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/feature/blocking/junk/JunkState.kt
@@ -1,0 +1,19 @@
+/*
+ * Copyright (C) 2025
+ *
+ * This file is part of QUIK.
+ *
+ * QUIK is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ */
+package dev.octoshrimpy.quik.feature.blocking.junk
+
+import dev.octoshrimpy.quik.model.Message
+import io.realm.RealmResults
+
+data class JunkState(
+    val data: RealmResults<Message>? = null,
+    val selected: Int = 0
+)

--- a/presentation/src/main/java/com/moez/QKSMS/feature/blocking/junk/JunkView.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/feature/blocking/junk/JunkView.kt
@@ -1,0 +1,29 @@
+/*
+ * Copyright (C) 2025
+ *
+ * This file is part of QUIK.
+ *
+ * QUIK is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ */
+package dev.octoshrimpy.quik.feature.blocking.junk
+
+import dev.octoshrimpy.quik.common.base.QkViewContract
+import io.reactivex.Observable
+import io.reactivex.subjects.Subject
+
+interface JunkView : QkViewContract<JunkState> {
+
+    val menuReadyIntent: Subject<Unit>
+    val optionsItemIntent: Subject<Int>
+    val selectionChanges: Observable<List<Long>>
+    val confirmDeleteIntent: Subject<List<Long>>
+    val backClicked: Subject<Unit>
+
+    fun clearSelection()
+    fun showDeleteDialog(messageIds: List<Long>)
+    fun goBack()
+
+}

--- a/presentation/src/main/java/com/moez/QKSMS/injection/AppComponent.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/injection/AppComponent.kt
@@ -36,6 +36,7 @@ import dev.octoshrimpy.quik.feature.blocking.filters.MessageContentFiltersContro
 import dev.octoshrimpy.quik.feature.blocking.manager.BlockingManagerController
 import dev.octoshrimpy.quik.feature.blocking.messages.BlockedMessagesController
 import dev.octoshrimpy.quik.feature.blocking.numbers.BlockedNumbersController
+import dev.octoshrimpy.quik.feature.blocking.junk.JunkController
 import dev.octoshrimpy.quik.feature.compose.editing.DetailedChipView
 import dev.octoshrimpy.quik.feature.conversationinfo.injection.ConversationInfoComponent
 import dev.octoshrimpy.quik.feature.messageutils.MessageUtilsController
@@ -70,6 +71,7 @@ interface AppComponent {
     fun inject(controller: MessageContentFiltersController)
     fun inject(controller: BlockingController)
     fun inject(controller: BlockingManagerController)
+    fun inject(controller: JunkController)
     fun inject(controller: MessageUtilsController)
     fun inject(controller: SettingsController)
     fun inject(controller: SwipeActionsController)

--- a/presentation/src/main/res/layout/blocking_controller.xml
+++ b/presentation/src/main/res/layout/blocking_controller.xml
@@ -66,6 +66,13 @@
             android:layout_height="wrap_content"
             app:title="@string/blocked_messages_title" />
 
+        <dev.octoshrimpy.quik.common.widget.PreferenceView
+            android:id="@+id/junk"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            app:summary="@string/junk_summary"
+            app:title="@string/junk_title" />
+
     </LinearLayout>
 
 </ScrollView>

--- a/presentation/src/main/res/layout/junk_controller.xml
+++ b/presentation/src/main/res/layout/junk_controller.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="?android:attr/windowBackground">
+
+    <dev.octoshrimpy.quik.common.widget.QkTextView
+        android:id="@+id/empty"
+        style="@style/TextSecondary"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:gravity="center"
+        android:padding="56dp"
+        android:text="@string/junk_empty" />
+
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/messages"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:paddingTop="8dp"
+        android:paddingBottom="8dp"
+        app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
+        tools:listitem="@layout/junk_list_item" />
+
+</FrameLayout>

--- a/presentation/src/main/res/layout/junk_list_item.xml
+++ b/presentation/src/main/res/layout/junk_list_item.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:background="?attr/selectableItemBackground"
+    android:paddingStart="16dp"
+    android:paddingEnd="16dp"
+    android:paddingTop="8dp"
+    android:paddingBottom="8dp">
+
+    <dev.octoshrimpy.quik.common.widget.QkTextView
+        android:id="@+id/address"
+        style="@style/TextPrimary"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:singleLine="true"
+        android:ellipsize="end"
+        android:textDirection="ltr"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toStartOf="@id/date"
+        app:layout_constraintTop_toTopOf="parent"
+        app:textSize="primary"
+        tools:text="+1 555 555 5555" />
+
+    <dev.octoshrimpy.quik.common.widget.QkTextView
+        android:id="@+id/date"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:textColor="?android:attr/textColorTertiary"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toTopOf="@id/address"
+        app:layout_constraintBottom_toBottomOf="@id/address"
+        app:textSize="tertiary"
+        tools:text="Oct 5" />
+
+    <dev.octoshrimpy.quik.common.widget.QkTextView
+        android:id="@+id/body"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="4dp"
+        android:maxLines="3"
+        android:ellipsize="end"
+        android:textColor="?android:attr/textColorSecondary"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/address"
+        app:textSize="secondary"
+        tools:text="We're in your neighborhood trimming trees and have GIANT discounts." />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/presentation/src/main/res/menu/junk.xml
+++ b/presentation/src/main/res/menu/junk.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+
+    <item
+        android:id="@+id/restore"
+        android:icon="@drawable/ic_inbox_black_24dp"
+        android:title="@string/junk_menu_restore"
+        android:visible="false"
+        app:showAsAction="ifRoom" />
+
+    <item
+        android:id="@+id/delete"
+        android:icon="@drawable/ic_delete_white_24dp"
+        android:title="@string/main_menu_delete"
+        android:visible="false"
+        app:showAsAction="ifRoom" />
+
+</menu>

--- a/presentation/src/main/res/menu/message_content_filters.xml
+++ b/presentation/src/main/res/menu/message_content_filters.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+
+    <item
+        android:id="@+id/import_json"
+        android:icon="@drawable/ic_import_export_black_24dp"
+        android:title="@string/message_content_filters_menu_import"
+        app:showAsAction="ifRoom" />
+
+</menu>

--- a/presentation/src/main/res/values/strings.xml
+++ b/presentation/src/main/res/values/strings.xml
@@ -375,9 +375,28 @@
     <string name="message_content_filters_dialog_regex_switch">Regular expression</string>
     <string name="message_content_filters_dialog_contacts_switch">Include contacts</string>
     <string name="message_content_filters_dialog_create">Create</string>
+    <string name="message_content_filters_menu_import">Import from JSON</string>
+    <string name="message_content_filters_import_result_title">Import complete</string>
+    <string name="message_content_filters_import_error_title">Import failed</string>
+    <string name="message_content_filters_import_error">Could not read filter file</string>
+    <string name="message_content_filters_import_regex_errors_title">Invalid regex filters skipped</string>
+    <plurals name="message_content_filters_import_result">
+        <item quantity="one">Imported %d filter (%d skipped)</item>
+        <item quantity="other">Imported %d filters (%d skipped)</item>
+    </plurals>
 
     <string name="blocked_messages_title">Blocked messages</string>
     <string name="blocked_messages_empty">Your blocked messages will appear here</string>
+
+    <string name="junk_title">Junk</string>
+    <string name="junk_empty">Messages caught by content filters will appear here</string>
+    <string name="junk_summary">Review messages caught by content filters</string>
+    <string name="junk_menu_restore">Restore</string>
+    <string name="junk_delete_dialog_title">Delete junk messages?</string>
+    <plurals name="junk_delete_dialog_message">
+        <item quantity="one">Permanently delete %d message?</item>
+        <item quantity="other">Permanently delete %d messages?</item>
+    </plurals>
 
     <string name="blocking_block_title">Block</string>
     <string name="blocking_unblock_title">Unblock</string>


### PR DESCRIPTION
Adds a Junk screen under Settings > Blocking that quarantines messages caught by content filters instead of dropping them when Drop is off, plus JSON import for content filters.

Behaviour changes worth flagging:

* When `Drop` is off, filtered messages are now quarantined to Junk instead of unconditionally deleted. Previously the Drop toggle only gated the blocking client's Block action; content-filter matches were always deleted. Junk screen has Restore and Delete.
* Regex filters previously required a whole-string match (`Regex.matches`). This PR switches to `containsMatchIn` and adds `DOT_MATCHES_ALL`. Users with unanchored patterns like `spam` will now match any message containing "spam" rather than only messages equal to "spam". Case-sensitive flag is honored for regex now.
* Regex filters are compiled once per filter id and cached (invalidated on delete) rather than recompiled per message per filter.

Data:

* Schema migration 15 -> 16 adds a `junk` boolean to `Message`, defaulted to false.
* `SyncRepositoryImpl` re-hydrates the junk flag on both full and partial sync paths so quarantine state survives an SMS provider re-sync.

JSON import shape (Settings > Blocking > Content filters > overflow menu > Import from JSON):

Action must be set to `junk` otherwise the filter is dropped.

```json
  {
    "id": "ABA17A20-E66D-465E-8C88-284D1BE9564A",
    "phrase": "(whole[- ]home|standby|home|generator) generator|generator (install|quote)",
    "action": "junk",
    "useRegex": true,
    "caseSensitive": false
  },
```

Import bounds the file at 1 MB, caps at 10,000 entries, caps phrase length at 4 KB, and probes each regex against a pathological input with a 200 ms timeout to catch catastrophic backtracking at import time rather than at receive time.

Tested locally on device with schema-migration from v15, filter import, message quarantine on receive, restore, and delete flows.

versionCode / versionName bump intentionally not included. Happy to add whichever the maintainers prefer.

Fixes # N/A

<img width="480" height="854" alt="image" src="https://github.com/user-attachments/assets/3de98073-6de5-46dc-b62d-46fea57f3e3d" />

<img width="480" height="854" alt="image" src="https://github.com/user-attachments/assets/0449346d-0b6e-4c44-8a76-337e0e2aff75" />

